### PR TITLE
fix: reset replay data on new game

### DIFF
--- a/ffi/src/game_reporter.rs
+++ b/ffi/src/game_reporter.rs
@@ -1,5 +1,8 @@
 use std::ffi::c_char;
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use slippi_game_reporter::{GameReport, OnlinePlayMode as ReporterOnlinePlayMode, PlayerReport};
 
 use crate::{c_str_to_string, with};
@@ -96,7 +99,7 @@ pub extern "C" fn slprs_game_report_create(
         lras_initiator,
         stage_id,
         players: Vec::new(),
-        replay_data: Vec::new(),
+        replay_data: Arc::new(Mutex::new(Vec::new())),
     });
 
     let report_instance_ptr = Box::into_raw(report) as usize;

--- a/game-reporter/src/queue.rs
+++ b/game-reporter/src/queue.rs
@@ -409,19 +409,20 @@ fn compress_to_gzip(input: &[u8], output: &mut [u8]) -> Result<usize, std::io::E
 }
 
 /// Attempts to compress and upload replay data to the url at `upload_url`.
-fn try_upload_replay_data(data: Arc<Vec<u8>>, upload_url: String, http_client: &ureq::Agent) {
-    let raw_data_size = data.len() as u32;
+fn try_upload_replay_data(data: Arc<Mutex<Vec<u8>>>, upload_url: String, http_client: &ureq::Agent) {
+    let guard = data.lock().unwrap();
+    let raw_data_size = guard.len() as u32;
     let rdbs = raw_data_size.to_le_bytes();
 
     // Add header and footer to replay file
     let mut contents = vec![
         b'{', b'U', 3, b'r', b'a', b'w', b'[', b'$', b'U', b'#', b'l', rdbs[3], rdbs[2], rdbs[1], rdbs[0],
     ];
-    contents.extend_from_slice(&data);
+    contents.extend_from_slice(&guard);
     let mut footer = vec![b'U', 8, b'm', b'e', b't', b'a', b'd', b'a', b't', b'a', b'{', b'}', b'}'];
     contents.append(&mut footer);
 
-    let mut gzipped_data = vec![0u8; data.len()]; // Resize to some initial size
+    let mut gzipped_data = vec![0u8; guard.len()]; // Resize to some initial size
 
     let res_size = match compress_to_gzip(&contents, &mut gzipped_data) {
         Ok(size) => size,
@@ -433,6 +434,9 @@ fn try_upload_replay_data(data: Arc<Vec<u8>>, upload_url: String, http_client: &
     };
 
     gzipped_data.resize(res_size, 0);
+
+    // Drop guard here before running the upload, since we don't need it anymore.
+    drop(guard);
 
     let response = http_client
         .put(upload_url.as_str())

--- a/game-reporter/src/queue.rs
+++ b/game-reporter/src/queue.rs
@@ -409,7 +409,7 @@ fn compress_to_gzip(input: &[u8], output: &mut [u8]) -> Result<usize, std::io::E
 }
 
 /// Attempts to compress and upload replay data to the url at `upload_url`.
-fn try_upload_replay_data(data: Vec<u8>, upload_url: String, http_client: &ureq::Agent) {
+fn try_upload_replay_data(data: Arc<Vec<u8>>, upload_url: String, http_client: &ureq::Agent) {
     let raw_data_size = data.len() as u32;
     let rdbs = raw_data_size.to_le_bytes();
 

--- a/game-reporter/src/types.rs
+++ b/game-reporter/src/types.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
 /// The different modes that a player could be in.
 ///
 /// Note that this type uses `serde_repr` to ensure we serialize the value (C-style)
@@ -30,7 +33,7 @@ pub struct GameReport {
 
     // This is set when we log the report. Anything before then
     // is a non-allocated `Vec<u8>` to just be a placeholder.
-    pub replay_data: std::sync::Arc<Vec<u8>>,
+    pub replay_data: Arc<Mutex<Vec<u8>>>,
 }
 
 /// Player metadata payload that's logged with game info.

--- a/game-reporter/src/types.rs
+++ b/game-reporter/src/types.rs
@@ -30,7 +30,7 @@ pub struct GameReport {
 
     // This is set when we log the report. Anything before then
     // is a non-allocated `Vec<u8>` to just be a placeholder.
-    pub replay_data: Vec<u8>,
+    pub replay_data: std::sync::Arc<Vec<u8>>,
 }
 
 /// Player metadata payload that's logged with game info.


### PR DESCRIPTION
also attempts to allow reference to linger long enough for game end to be added before data actually gets uploaded