### PR TITLE
Experimental patch that enforces IPV4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,10 +1129,10 @@ version = "0.1.0"
 dependencies = [
  "dolphin-integrations",
  "slippi-game-reporter",
+ "slippi-gg-api",
  "slippi-jukebox",
  "slippi-user",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -1145,7 +1145,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "slippi-gg-api",
  "slippi-user",
+ "tracing",
+]
+
+[[package]]
+name = "slippi-gg-api"
+version = "0.1.0"
+dependencies = [
  "tracing",
  "ureq",
 ]
@@ -1182,8 +1190,8 @@ dependencies = [
  "open",
  "serde",
  "serde_json",
+ "slippi-gg-api",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -1419,9 +1427,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "ffi",
     "game-reporter",
     "jukebox",
+    "slippi-gg-api",
     "user",
 ]
 
@@ -32,7 +33,7 @@ serde_repr = { version = "0.1" }
 # in extra dependencies.
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
-ureq = { version = "2.7.1", features = ["json"] }
+ureq = { version = "2.9.1", features = ["json"] }
 
 [patch.crates-io]
 # We need to patch this dependency to fix a bug in Windows where a crash can occur

--- a/dolphin/Cargo.toml
+++ b/dolphin/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 default = []
 ishiiruka = []
 mainline = []
+playback = []
 
 [dependencies]
 time = { workspace = true }

--- a/exi/Cargo.toml
+++ b/exi/Cargo.toml
@@ -11,13 +11,20 @@ publish = false
 
 [features]
 default = []
-ishiiruka = []
-mainline = []
+ishiiruka = [
+    "slippi-gg-api/ishiiruka"
+]
+mainline = [
+    "slippi-gg-api/mainline"
+]
+playback = [
+    "slippi-gg-api/playback"
+]
 
 [dependencies]
 dolphin-integrations = { path = "../dolphin" }
 slippi-game-reporter = { path = "../game-reporter" }
+slippi-gg-api = { path = "../slippi-gg-api" }
 slippi-jukebox = { path = "../jukebox" }
 slippi-user = { path = "../user" }
 tracing = { workspace = true }
-ureq = { workspace = true }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,8 +24,18 @@ ishiiruka = [
     "slippi-exi-device/ishiiruka",
     "slippi-user/ishiiruka"
 ]
-mainline = []
-playback = []
+mainline = [
+    "dolphin-integrations/mainline",
+    "slippi-game-reporter/mainline",
+    "slippi-exi-device/mainline",
+    "slippi-user/mainline"
+]
+playback = [
+    "dolphin-integrations/playback",
+    "slippi-game-reporter/playback",
+    "slippi-exi-device/playback",
+    "slippi-user/playback"
+]
 
 [dependencies]
 dolphin-integrations = { path = "../dolphin" }

--- a/game-reporter/Cargo.toml
+++ b/game-reporter/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 default = []
 ishiiruka = []
 mainline = []
+playback = []
 
 [dependencies]
 chksum = { version = "0.2.2", default-features = false, features = ["md5"] }
@@ -18,6 +19,6 @@ flate2 = "1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = { workspace = true }
+slippi-gg-api = { path = "../slippi-gg-api" }
 slippi-user = { path = "../user" }
 tracing = { workspace = true }
-ureq = { workspace = true }

--- a/game-reporter/src/lib.rs
+++ b/game-reporter/src/lib.rs
@@ -7,9 +7,8 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
 
-use ureq::Agent;
-
 use dolphin_integrations::Log;
+use slippi_gg_api::APIClient;
 use slippi_user::UserManager;
 
 mod iso_md5_hasher;
@@ -68,8 +67,8 @@ impl GameReporter {
     ///
     /// Currently, failure to spawn any thread should result in a crash - i.e, if we can't
     /// spawn an OS thread, then there are probably far bigger issues at work here.
-    pub fn new(http_client: Agent, user_manager: UserManager, iso_path: String) -> Self {
-        let queue = GameReporterQueue::new(http_client.clone());
+    pub fn new(api_client: APIClient, user_manager: UserManager, iso_path: String) -> Self {
+        let queue = GameReporterQueue::new(api_client.clone());
 
         // This is a thread-safe "one time" setter that the MD5 hasher thread
         // will set when it's done computing.
@@ -97,7 +96,7 @@ impl GameReporter {
         let completion_thread = thread::Builder::new()
             .name("GameReporterCompletionProcessingThread".into())
             .spawn(move || {
-                queue::run_completion(http_client, completion_receiver);
+                queue::run_completion(api_client, completion_receiver);
             })
             .expect("Failed to spawn GameReporterCompletionProcessingThread.");
 

--- a/slippi-gg-api/Cargo.toml
+++ b/slippi-gg-api/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "slippi-gg-api"
+description = "slippi.gg API client for internal calls."
+version = "0.1.0"
+authors = [
+    "Slippi Team",
+    "Ryan McGrath <ryan@rymc.io>"
+]
+repository = ""
+edition = "2021"
+publish = false
+
+[dependencies]
+ureq = { workspace = true }
+tracing = { workspace = true }
+
+[features]
+default = ["ishiiruka"]
+ishiiruka = []
+mainline = []
+playback = []

--- a/slippi-gg-api/src/lib.rs
+++ b/slippi-gg-api/src/lib.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::time::Duration;
 use std::ops::{Deref, DerefMut};
+use std::time::Duration;
 
 use ureq::{Agent, AgentBuilder, Resolver};
 
@@ -15,9 +15,7 @@ impl Resolver for Ipv4Resolver {
     /// Forces IPV4 addresses only.
     fn resolve(&self, netloc: &str) -> io::Result<Vec<SocketAddr>> {
         ToSocketAddrs::to_socket_addrs(netloc).map(|iter| {
-            let vec = iter
-                .filter(|s| s.is_ipv4())
-                .collect::<Vec<SocketAddr>>();
+            let vec = iter.filter(|s| s.is_ipv4()).collect::<Vec<SocketAddr>>();
 
             if vec.is_empty() {
                 tracing::warn!("Failed to get any IPV4 addresses. Does the DNS server support it?");

--- a/slippi-gg-api/src/lib.rs
+++ b/slippi-gg-api/src/lib.rs
@@ -44,14 +44,16 @@ impl APIClient {
     /// The returned client will only resolve to IPV4 addresses at the moment
     /// due to upstream issues with GCP flex instances and IPV6.
     pub fn new(slippi_semver: &str) -> Self {
+        let _build = "";
+
         #[cfg(feature = "mainline")]
-        let build = "mainline";
+        let _build = "mainline";
 
         #[cfg(feature = "ishiiruka")]
-        let build = "ishiiruka";
+        let _build = "ishiiruka";
 
         #[cfg(feature = "playback")]
-        let build = "playback";
+        let _build = "playback";
 
         // We set `max_idle_connections` to `5` to mimic how CURL was configured in
         // the old C++ logic. This gets cloned and passed down into modules so that
@@ -60,7 +62,7 @@ impl APIClient {
             .resolver(Ipv4Resolver)
             .max_idle_connections(5)
             .timeout(Duration::from_millis(5000))
-            .user_agent(&format!("SlippiDolphin/{} ({}) (Rust)", build, slippi_semver))
+            .user_agent(&format!("SlippiDolphin/{} ({}) (Rust)", _build, slippi_semver))
             .build();
 
         Self(http_client)

--- a/slippi-gg-api/src/lib.rs
+++ b/slippi-gg-api/src/lib.rs
@@ -1,0 +1,84 @@
+use std::io;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::time::Duration;
+use std::ops::{Deref, DerefMut};
+
+use ureq::{Agent, AgentBuilder, Resolver};
+
+/// Re-export `ureq::Error` for simplicity.
+pub type Error = ureq::Error;
+
+/// A DNS resolver that only accepts IPV4 connections.
+struct Ipv4Resolver;
+
+impl Resolver for Ipv4Resolver {
+    /// Forces IPV4 addresses only.
+    fn resolve(&self, netloc: &str) -> io::Result<Vec<SocketAddr>> {
+        ToSocketAddrs::to_socket_addrs(netloc).map(|iter| {
+            let vec = iter
+                .filter(|s| s.is_ipv4())
+                .collect::<Vec<SocketAddr>>();
+
+            if vec.is_empty() {
+                tracing::warn!("Failed to get any IPV4 addresses. Does the DNS server support it?");
+            }
+
+            vec
+        })
+    }
+}
+
+/// A wrapper type that simply dereferences to a `ureq::Agent`.
+///
+/// It's extracted purely for ease of debugging, and for segmenting
+/// some initial setup code that would just be cumbersome to do in the
+/// core EXI device initialization block.
+///
+/// Anything that can be called on a `ureq::Agent` can be called on
+/// this type. You can also clone this with little cost, and pass it freely
+/// to other threads, as it manages itself under the hood with `Arc`.
+#[derive(Clone, Debug)]
+pub struct APIClient(Agent);
+
+impl APIClient {
+    /// Creates and initializes a new APIClient.
+    ///
+    /// The returned client will only resolve to IPV4 addresses at the moment
+    /// due to upstream issues with GCP flex instances and IPV6.
+    pub fn new(slippi_semver: &str) -> Self {
+        #[cfg(feature = "mainline")]
+        let build = "mainline";
+
+        #[cfg(feature = "ishiiruka")]
+        let build = "ishiiruka";
+
+        #[cfg(feature = "playback")]
+        let build = "playback";
+
+        // We set `max_idle_connections` to `5` to mimic how CURL was configured in
+        // the old C++ logic. This gets cloned and passed down into modules so that
+        // the underlying connection pool is shared.
+        let http_client = AgentBuilder::new()
+            .resolver(Ipv4Resolver)
+            .max_idle_connections(5)
+            .timeout(Duration::from_millis(5000))
+            .user_agent(&format!("SlippiDolphin/{} ({}) (Rust)", build, slippi_semver))
+            .build();
+
+        Self(http_client)
+    }
+}
+
+impl Deref for APIClient {
+    type Target = Agent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for APIClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -20,5 +20,5 @@ dolphin-integrations = { path = "../dolphin" }
 open = "5"
 serde = { workspace = true }
 serde_json = { workspace = true }
+slippi-gg-api = { path = "../slippi-gg-api" }
 tracing = { workspace = true }
-ureq = { workspace = true }

--- a/user/src/watcher.rs
+++ b/user/src/watcher.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use ureq::Agent;
+use slippi_gg_api::APIClient;
 
 use super::{attempt_login, UserInfo};
 
@@ -28,7 +28,7 @@ impl UserInfoWatcher {
     /// Spins up (or re-spins-up) the background watcher thread for the `user.json` file.
     pub fn watch_for_login(
         &mut self,
-        http_client: Agent,
+        api_client: APIClient,
         user_json_path: Arc<PathBuf>,
         user: Arc<Mutex<UserInfo>>,
         slippi_semver: &str,
@@ -55,7 +55,7 @@ impl UserInfoWatcher {
                     return;
                 }
 
-                if attempt_login(&http_client, &user, &user_json_path, &slippi_semver) {
+                if attempt_login(&api_client, &user, &user_json_path, &slippi_semver) {
                     return;
                 }
 


### PR DESCRIPTION
This moves the core HTTP client into an external crate and implements a custom resolver to attempt to limit connections to IPV4 only.

The reasoning for the external crate: it simplifies debugging this and enables swapping out the underlying HTTP client adapter for any further debugging. I wouldn't necessarily consider this design complete and/or necessary, but this bug is tricky to reproduce and I'm not jumping over a bunch of files hunting down imports.

The reasoning for the bug: GCP appears to have some oddities with regards to IPV6 support, and if a device is configured to be IPV6-capable and a user does not have a DNS cache entry for the API, they may run into a randomly broken connection. I believe we never saw this with the curl connections that were in use on the C++ side as that implements a happy-eyeballs flow that attempts to find the "best" route and follow it accordingly. This patch just attempts to restrict things to ipv4 which we know works.

This patch is subject to further iterations as it may require vending a few debug builds to users to see if it works out.