### PR TITLE
fix: dashes to underscores in lib name to build with Cargo 1.79+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,19 +1170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slippi-rust-extensions"
-version = "0.1.0"
-dependencies = [
- "cbindgen",
- "dolphin-integrations",
- "slippi-exi-device",
- "slippi-game-reporter",
- "slippi-jukebox",
- "slippi-user",
- "tracing",
-]
-
-[[package]]
 name = "slippi-user"
 version = "0.1.0"
 dependencies = [
@@ -1191,6 +1178,19 @@ dependencies = [
  "serde",
  "serde_json",
  "slippi-gg-api",
+ "tracing",
+]
+
+[[package]]
+name = "slippi_rust_extensions"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "dolphin-integrations",
+ "slippi-exi-device",
+ "slippi-game-reporter",
+ "slippi-jukebox",
+ "slippi-user",
  "tracing",
 ]
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "slippi-rust-extensions"
+name = "slippi_rust_extensions"
 description = "An internal library that exposes entry points via the C FFI."
 version = "0.1.0"
 authors = [


### PR DESCRIPTION
Needed to merge [supermodule pull](https://github.com/project-slippi/Ishiiruka/pull/424).