### PR TITLE
Add Discord Rich Presence support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "discord-rich-presence"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,10 +1200,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slippi-discord-rpc"
+version = "0.1.0"
+dependencies = [
+ "discord-rich-presence",
+ "dolphin-integrations",
+ "slippi-user",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "slippi-exi-device"
 version = "0.1.0"
 dependencies = [
  "dolphin-integrations",
+ "slippi-discord-rpc",
  "slippi-game-reporter",
  "slippi-gg-api",
  "slippi-jukebox",
@@ -1551,6 +1579,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 default-members = ["ffi"]
 
 members = [
+    "discord-rpc",
     "dolphin",
     "exi",
     "ffi",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This workspace currently targets Rust `1.88.0`. As long as you have Rust install
 
 | Module                 | Description                                                                |
 |------------------------|----------------------------------------------------------------------------|
+| `discord-rpc`          | Discord Rich Presence. See the [Slippi Discord RPC README](discord-rpc/README.md) for more info. |
 | `dolphin`              | A library that wraps Dolphin callbacks (logging, etc).                     |
 | `exi`                  | EXI device that receives forwarded calls from the EXI (C++) device.        |
 | `ffi`                  | The core library. Exposes C FFI functions for Dolphin to call.             |

--- a/discord-rpc/Cargo.toml
+++ b/discord-rpc/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "slippi-discord-rpc"
+description = "Mirrors live Slippi game state (stage, characters, stocks, set score) to a locally running Discord client as Rich Presence."
+version = "0.1.0"
+authors = [
+    "Slippi Team",
+    "Anders Madsen <madsenanders97@gmail.com>"
+]
+edition = "2024"
+publish = false
+
+[features]
+default = []
+ishiiruka = []
+mainline = []
+playback = []
+
+[dependencies]
+discord-rich-presence = "1.1.0"
+dolphin-integrations = { path = "../dolphin" }
+slippi-user = { path = "../user" }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tracing-subscriber = "0.3"

--- a/discord-rpc/README.md
+++ b/discord-rpc/README.md
@@ -1,0 +1,78 @@
+# Slippi Discord Rich Presence
+
+Mirrors live Slippi online game state to a locally running Discord client: the
+stage, characters, live stock counts and set score during a match, plus the
+menu, queue and matchmaking flow between matches.
+
+## How it works
+
+Two data sources feed the presence, both on a single background thread
+(`SlippiDiscordRpc`) owned by `DiscordHandler`. Neither reads emulated memory.
+
+1. **The replay event stream.** Dolphin already tees the replay payloads the
+   EXI device receives into this crate. An incremental parser (`parser.rs`)
+   pulls out `Game Start` (stage, characters, names, match ID), `Post Frame`
+   (live stock counts) and `Game End` (placements, which drive the set score).
+
+2. **Slippi's matchmaking state** (`menu.rs`). Between games the C++ side pushes
+   the matchmaking state over `slprs_exi_device_update_matchmaking_state` each
+   online frame, straight from Slippi's own `SlippiMatchmaking`. The thread
+   edge-detects and only re-renders when it changes.
+
+Discord I/O is local IPC (Unix sockets on macOS/Linux, named pipes on Windows)
+via the `discord-rich-presence` crate; there is no networking here. If Discord
+isn't running, the thread retries and the rest of Slippi is unaffected. The
+rank shown while queueing comes from the `slippi-user` crate's `UserManager`,
+and is hidden when the player has hidden their rank in-game
+(`SLIPPI_ENABLE_RANK_LOCAL`).
+
+## Testing without Dolphin
+
+Both halves can be exercised against a real Discord client with no Dolphin
+build:
+
+```sh
+# Stream a real .slp replay through the parser at 8x speed.
+cargo run -p slippi-discord-rpc --example simulate -- path/to/replay.slp 8
+
+# Walk menus, queue and opponent-found by pushing matchmaking snapshots.
+cargo run -p slippi-discord-rpc --example simulate_queue
+
+# Print what the parser sees in a replay.
+cargo run -p slippi-discord-rpc --example dump -- path/to/replay.slp
+
+cargo test -p slippi-discord-rpc
+```
+
+## Dolphin integration
+
+Like the Jukebox, the Rust lives here and the small game-side glue lives in the
+Dolphin repo, joined by the cbindgen FFI header. The C++ side:
+
+- Tees `slprs_exi_device_reporter_push_replay_data` into this crate (already
+  called today; nothing new for in-game presence).
+- Calls `slprs_exi_device_configure_discord_rpc(ptr, is_enabled, show_rank)`
+  once, gating `is_enabled` on a `SLIPPI_ENABLE_DISCORD_RPC` setting (default
+  on, with a Slippi-pane checkbox like `SLIPPI_ENABLE_JUKEBOX`) and passing
+  `show_rank` from `SLIPPI_ENABLE_RANK_LOCAL`.
+- Calls `slprs_exi_device_update_matchmaking_state(ptr, process_state,
+  online_mode, opponent_name, opponent_rank)` each online frame from
+  `prepareOnlineMatchState()`.
+- Registers a `SLIPPI_RUST_DISCORD_RPC` log container in `LogManager.cpp`, like
+  `SLIPPI_RUST_JUKEBOX`.
+
+These edits ship as a small PR against
+[project-slippi/dolphin](https://github.com/project-slippi/dolphin).
+
+The Discord application ID and its image assets (`char{id}`, `stage{id}`, rank
+badges) are documented at the top of `presence.rs`. Two buttons, "Get Slippi"
+and a link to the player's `slippi.gg` profile, ride along on every update;
+Discord shows them only to other people viewing the profile.
+
+## Caveats
+
+- Only the online flow is covered. Offline modes (training, VS) and non-match
+  scenes have no matchmaking state and don't feed the replay stream, so they
+  show the generic "in menus".
+- The `ProcessState` / `OnlinePlayMode` integer values mirror Slippi's
+  `SlippiMatchmaking` enums, so the two stay in lockstep.

--- a/discord-rpc/examples/dump.rs
+++ b/discord-rpc/examples/dump.rs
@@ -1,0 +1,24 @@
+//! Parses a `.slp` file and dumps the events the presence pipeline sees.
+//! Debug aid only.
+
+use slippi_discord_rpc::{EventParser, SlpEvent, raw_replay_stream};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: dump <replay.slp>");
+    let file = std::fs::read(&path).expect("could not read replay file");
+    let stream = raw_replay_stream(&file).expect("not a valid .slp replay");
+
+    let mut parser = EventParser::new();
+    let mut post_frames_seen = 0;
+
+    parser.push(stream, |event| match event {
+        SlpEvent::GameStart(info) => println!("{info:#?}"),
+        SlpEvent::PostFrame { player, stocks, percent } => {
+            if post_frames_seen < 8 {
+                println!("PostFrame player={player} stocks={stocks} percent={percent}");
+            }
+            post_frames_seen += 1;
+        },
+        SlpEvent::GameEnd { .. } => println!("{event:?} (after {post_frames_seen} post-frames)"),
+    });
+}

--- a/discord-rpc/examples/simulate.rs
+++ b/discord-rpc/examples/simulate.rs
@@ -1,0 +1,67 @@
+//! Replays one or more `.slp` files through the Discord presence pipeline
+//! so the integration can be tested without building or running Dolphin.
+//! Passing multiple files from the same set exercises set-score tracking.
+//!
+//! Usage:
+//!     cargo run -p slippi-discord-rpc --example simulate -- <replay.slp>... [speed]
+//!
+//! `speed` is a playback multiplier (default 8). Have Discord running and
+//! watch your profile while this runs.
+
+use std::time::Duration;
+
+use slippi_discord_rpc::{DiscordHandler, raw_replay_stream};
+
+fn main() {
+    tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
+
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+
+    // A trailing integer argument is the speed multiplier.
+    let speed: u32 = match args.last().and_then(|arg| arg.parse().ok()) {
+        Some(speed) => {
+            args.pop();
+            speed
+        },
+        None => 8,
+    };
+
+    assert!(!args.is_empty(), "usage: simulate <replay.slp>... [speed]");
+
+    let handler = DiscordHandler::new(None).expect("could not start the presence handler");
+
+    // Feed each stream in chunks, pacing by approximate frame density so
+    // the presence updates roll in like a real (sped up) game. A frame of
+    // replay data is roughly 400 bytes, and Melee runs at 60 frames a
+    // second.
+    let bytes_per_second = 400 * 60 * speed as usize;
+    let chunk_size = bytes_per_second / 20;
+
+    for (i, path) in args.iter().enumerate() {
+        let file = std::fs::read(path).expect("could not read replay file");
+        let stream = raw_replay_stream(&file).expect("not a valid .slp replay");
+
+        println!(
+            "Game {}: {} ({} bytes of event data) at {speed}x speed",
+            i + 1,
+            path,
+            stream.len()
+        );
+
+        for chunk in stream.chunks(chunk_size) {
+            handler.push_replay_data(chunk);
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // Linger on the result like the post-game screen would.
+        std::thread::sleep(Duration::from_secs(6));
+    }
+
+    println!("Set complete; holding presence for 10 seconds...");
+    std::thread::sleep(Duration::from_secs(10));
+
+    // Dropping the handler shuts the thread down and clears the activity.
+    drop(handler);
+
+    println!("Done.");
+}

--- a/discord-rpc/examples/simulate_queue.rs
+++ b/discord-rpc/examples/simulate_queue.rs
@@ -1,0 +1,48 @@
+//! Walks the Discord presence through the menu / matchmaking flow by pushing
+//! `update_matchmaking_state` snapshots, the same way Slippi's C++ side does.
+//! No Dolphin or emulated memory needed.
+//!
+//! Usage:
+//!     cargo run -p slippi-discord-rpc --example simulate_queue
+//!
+//! Have Discord running and watch your profile move through the matchmaking
+//! states.
+
+use std::time::Duration;
+
+use slippi_discord_rpc::DiscordHandler;
+
+// SlippiMatchmaking::ProcessState
+const IDLE: u8 = 0;
+const MATCHMAKING: u8 = 2;
+const OPPONENT_CONNECTING: u8 = 3;
+const CONNECTION_SUCCESS: u8 = 4;
+
+// SlippiMatchmaking::OnlinePlayMode
+const RANKED: u8 = 0;
+
+fn main() {
+    tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).init();
+
+    let handler = DiscordHandler::new(None).expect("could not start the presence handler");
+
+    let step = |label: &str, process: u8, mode: u8, opponent: Option<&str>, rank: i8| {
+        println!("--- {label}");
+        handler.update_matchmaking_state(process, mode, opponent.map(str::to_string), rank);
+        std::thread::sleep(Duration::from_secs(6));
+    };
+
+    step("In menus", IDLE, RANKED, None, -1);
+    step("In queue - Ranked", MATCHMAKING, RANKED, None, -1);
+    step(
+        "Opponent found - Mango (Diamond 1)",
+        OPPONENT_CONNECTING,
+        RANKED,
+        Some("Mango"),
+        13,
+    );
+    step("Starting match", CONNECTION_SUCCESS, RANKED, Some("Mango"), 13);
+
+    println!("--- Done; clearing presence");
+    drop(handler);
+}

--- a/discord-rpc/src/content.rs
+++ b/discord-rpc/src/content.rs
@@ -1,0 +1,138 @@
+//! Turns the presence thread's state into the strings shown in a Discord
+//! update. Pure rendering; `PresenceRunner` owns the state these read.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::melee;
+use crate::parser::GameStartInfo;
+
+/// Everything needed to render one presence update.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct PresenceContent {
+    pub details: String,
+    pub state: String,
+    pub large_image: String,
+    pub large_text: String,
+    pub small_image: Option<String>,
+    pub small_text: Option<String>,
+    pub start_timestamp: Option<i64>,
+    /// `(current, max)` party size, rendered by Discord as "(current of max)".
+    pub party: Option<(u32, u32)>,
+}
+
+/// State of the game currently being played, built up from replay events.
+#[derive(Debug, Default)]
+pub(crate) struct GameState {
+    pub info: GameStartInfo,
+    pub stocks: [u8; 4],
+    pub started_at: i64,
+    pub ended: bool,
+}
+
+/// Wins per port for the current set; reset whenever the match ID changes.
+#[derive(Debug, Default)]
+pub(crate) struct SetScore {
+    pub match_id: String,
+    pub wins: [u8; 4],
+}
+
+/// Maps a rank index to its display name, which also derives the asset key.
+pub(crate) fn rank_name(rank: i8) -> Option<&'static str> {
+    Some(match rank {
+        1 => "Bronze 1",
+        2 => "Bronze 2",
+        3 => "Bronze 3",
+        4 => "Silver 1",
+        5 => "Silver 2",
+        6 => "Silver 3",
+        7 => "Gold 1",
+        8 => "Gold 2",
+        9 => "Gold 3",
+        10 => "Platinum 1",
+        11 => "Platinum 2",
+        12 => "Platinum 3",
+        13 => "Diamond 1",
+        14 => "Diamond 2",
+        15 => "Diamond 3",
+        16 => "Master 1",
+        17 => "Master 2",
+        18 => "Master 3",
+        19 => "Grandmaster",
+        _ => return None,
+    })
+}
+
+/// Derives the Discord rank-badge asset key from a rank display name,
+/// e.g. "Diamond 1" -> "diamond_1".
+pub(crate) fn rank_asset_key(name: &str) -> String {
+    name.to_lowercase().replace(' ', "_")
+}
+
+/// The `details` line for an in-game activity: the mode, game number within
+/// the set, and (once a game ends) the running set score.
+pub(crate) fn game_details(game: &GameState, set_score: &SetScore) -> String {
+    let mode = match &game.info.match_id {
+        id if id.contains("mode.ranked") => "Ranked",
+        id if id.contains("mode.unranked") => "Unranked",
+        id if id.contains("mode.direct") => "Direct",
+        id if id.contains("mode.teams") => "Teams",
+        _ => "Online",
+    };
+
+    let mut details = mode.to_string();
+
+    if game.info.game_number > 0 {
+        details.push_str(&format!(" - Game {}", game.info.game_number));
+    }
+
+    if game.info.tiebreaker_number > 0 {
+        details.push_str(" (tiebreak)");
+    }
+
+    if game.ended {
+        let wins: Vec<String> = game
+            .info
+            .players
+            .iter()
+            .map(|p| set_score.wins[p.port as usize].to_string())
+            .collect();
+
+        details.push_str(&format!(" - Set {}", wins.join("-")));
+    }
+
+    details
+}
+
+/// The `state` line for an in-game activity: the two players and their live
+/// stock counts, or a game-over summary once the game ends.
+pub(crate) fn game_state_line(game: &GameState) -> String {
+    let players = &game.info.players;
+
+    if players.len() != 2 {
+        return "In game".to_string();
+    }
+
+    let name = |i: usize| -> String {
+        if !players[i].display_name.is_empty() {
+            players[i].display_name.clone()
+        } else {
+            melee::character_name(players[i].character_id).unwrap_or("Player").to_string()
+        }
+    };
+
+    if game.ended {
+        return format!("{} vs {} - Game over", name(0), name(1));
+    }
+
+    let stocks = |i: usize| game.stocks[players[i].port as usize];
+
+    format!("{} {} - {} {}", name(0), stocks(0), stocks(1), name(1))
+}
+
+/// Current Unix time in seconds.
+pub(crate) fn unix_time() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/discord-rpc/src/errors.rs
+++ b/discord-rpc/src/errors.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DiscordRpcError {
+    #[error("Failed to spawn thread: {0}")]
+    ThreadSpawn(std::io::Error),
+
+    #[error("The channel sender has disconnected, implying no further messages will be received.")]
+    ChannelDisconnected(#[from] std::sync::mpsc::RecvTimeoutError),
+}

--- a/discord-rpc/src/lib.rs
+++ b/discord-rpc/src/lib.rs
@@ -1,0 +1,142 @@
+//! Discord Rich Presence for Slippi Dolphin.
+
+use std::sync::mpsc::{self, Sender};
+use std::thread;
+
+use dolphin_integrations::Log;
+use slippi_user::UserManager;
+
+mod errors;
+use DiscordRpcError::*;
+pub use errors::DiscordRpcError;
+
+mod content;
+mod melee;
+mod menu;
+mod presence;
+mod scene;
+mod text;
+
+mod parser;
+pub use parser::{EventParser, GameStartInfo, PlayerInfo, SlpEvent, raw_replay_stream};
+
+pub(crate) type Result<T> = std::result::Result<T, DiscordRpcError>;
+
+/// Messages handled by the presence thread.
+#[derive(Debug)]
+pub(crate) enum Message {
+    /// A chunk of the replay event stream, fed to the parser.
+    ReplayData(Vec<u8>),
+
+    /// A matchmaking-state snapshot pushed from the C++ side each online frame.
+    Matchmaking {
+        process_state: u8,
+        online_mode: u8,
+        opponent_name: Option<String>,
+        opponent_rank: i8,
+    },
+
+    /// A scene + character-select snapshot pushed from the C++ side each
+    /// menu-frame heartbeat. Drives character-select and offline-scene presence.
+    Scene {
+        major: u8,
+        minor: u8,
+        char_ids: [u8; 4],
+        local_port: u8,
+        stage_id: u8,
+    },
+
+    /// The player's in-game rank-display setting changed.
+    ShowRank(bool),
+
+    /// The handle was dropped; shut the thread down.
+    Shutdown,
+}
+
+/// The public handle for the Discord Rich Presence integration.
+#[derive(Debug)]
+pub struct DiscordHandler {
+    sender: Sender<Message>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl DiscordHandler {
+    /// Spawns the presence thread and returns the handle.
+    pub fn new(user_manager: Option<UserManager>) -> Result<Self> {
+        tracing::info!(target: Log::DiscordRpc, "Initializing Discord Rich Presence");
+
+        let (sender, receiver) = mpsc::channel();
+
+        let thread = thread::Builder::new()
+            .name("SlippiDiscordRpc".to_string())
+            .spawn(move || {
+                if let Err(error) = presence::run(receiver, user_manager) {
+                    tracing::error!(target: Log::DiscordRpc, ?error, "Discord presence thread encountered an error");
+                }
+            })
+            .map_err(ThreadSpawn)?;
+
+        Ok(Self {
+            sender,
+            thread: Some(thread),
+        })
+    }
+
+    /// Forwards a chunk of the replay event stream to the presence thread.
+    pub fn push_replay_data(&self, data: &[u8]) {
+        // Fired every online frame; a dead channel means the thread is already
+        // gone, so we stay quiet here rather than spam the log on the hot path.
+        let _ = self.sender.send(Message::ReplayData(data.to_vec()));
+    }
+
+    /// Forwards a Slippi matchmaking-state snapshot to the presence thread.
+    pub fn update_matchmaking_state(&self, process_state: u8, online_mode: u8, opponent_name: Option<String>, opponent_rank: i8) {
+        let message = Message::Matchmaking {
+            process_state,
+            online_mode,
+            opponent_name,
+            opponent_rank,
+        };
+
+        if let Err(error) = self.sender.send(message) {
+            tracing::warn!(target: Log::DiscordRpc, ?error, "Unable to dispatch matchmaking state to presence thread");
+        }
+    }
+
+    /// Forwards a Slippi scene + character-select snapshot to the presence thread.
+    pub fn update_scene_state(&self, major: u8, minor: u8, char_ids: [u8; 4], local_port: u8, stage_id: u8) {
+        let message = Message::Scene {
+            major,
+            minor,
+            char_ids,
+            local_port,
+            stage_id,
+        };
+
+        if let Err(error) = self.sender.send(message) {
+            tracing::warn!(target: Log::DiscordRpc, ?error, "Unable to dispatch scene state to presence thread");
+        }
+    }
+
+    /// Mirrors the player's in-game rank-display setting
+    /// (`SLIPPI_ENABLE_RANK_LOCAL`); when false, the rank badge is hidden.
+    pub fn set_show_rank(&self, show_rank: bool) {
+        if let Err(error) = self.sender.send(Message::ShowRank(show_rank)) {
+            tracing::warn!(target: Log::DiscordRpc, ?error, "Unable to dispatch rank-display setting to presence thread");
+        }
+    }
+}
+
+impl Drop for DiscordHandler {
+    fn drop(&mut self) {
+        if let Err(error) = self.sender.send(Message::Shutdown) {
+            tracing::error!(target: Log::DiscordRpc, ?error, "Failed to notify Discord presence thread of shutdown, join may hang");
+        }
+
+        if let Some(thread) = self.thread.take() {
+            if let Err(error) = thread.join() {
+                tracing::error!(target: Log::DiscordRpc, ?error, "Discord presence thread panicked");
+            }
+        }
+    }
+}

--- a/discord-rpc/src/melee.rs
+++ b/discord-rpc/src/melee.rs
@@ -1,0 +1,140 @@
+//! Melee ID lookups (characters and stages) and the Discord asset names they
+//! map to. IDs are the external IDs from the Slippi `Game Start` event, not the
+//! in-game internal IDs.
+//! See https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
+
+/// Returns the display name for an external character ID, if known.
+pub(crate) fn character_name(id: u8) -> Option<&'static str> {
+    Some(match id {
+        0x00 => "Captain Falcon",
+        0x01 => "Donkey Kong",
+        0x02 => "Fox",
+        0x03 => "Mr. Game & Watch",
+        0x04 => "Kirby",
+        0x05 => "Bowser",
+        0x06 => "Link",
+        0x07 => "Luigi",
+        0x08 => "Mario",
+        0x09 => "Marth",
+        0x0A => "Mewtwo",
+        0x0B => "Ness",
+        0x0C => "Peach",
+        0x0D => "Pikachu",
+        0x0E => "Ice Climbers",
+        0x0F => "Jigglypuff",
+        0x10 => "Samus",
+        0x11 => "Yoshi",
+        0x12 => "Zelda",
+        0x13 => "Sheik",
+        0x14 => "Falco",
+        0x15 => "Young Link",
+        0x16 => "Dr. Mario",
+        0x17 => "Roy",
+        0x18 => "Pichu",
+        0x19 => "Ganondorf",
+        _ => return None,
+    })
+}
+
+/// Returns the Discord asset key for an external character ID.
+pub(crate) fn character_asset(id: u8) -> String {
+    match character_name(id) {
+        Some(_) => format!("char{id}"),
+        None => "questionmark".to_string(),
+    }
+}
+
+/// Returns the display name for an internal stage ID, the value Melee keeps for
+/// the currently loaded stage (as opposed to the external `Game Start` ID).
+pub(crate) fn stage_name_internal(internal_id: u16) -> Option<&'static str> {
+    Some(match internal_id {
+        2 => "Princess Peach's Castle",
+        3 => "Rainbow Cruise",
+        4 => "Kongo Jungle",
+        5 => "Jungle Japes",
+        6 => "Great Bay",
+        7 => "Temple",
+        8 => "Brinstar",
+        9 => "Brinstar Depths",
+        10 => "Yoshi's Story",
+        11 => "Yoshi's Island",
+        12 => "Fountain of Dreams",
+        13 => "Green Greens",
+        14 => "Corneria",
+        15 => "Venom",
+        16 => "Pokémon Stadium",
+        17 => "Poké Floats",
+        18 => "Mute City",
+        19 => "Big Blue",
+        20 => "Onett",
+        21 => "Fourside",
+        22 => "Icicle Mountain",
+        24 => "Mushroom Kingdom",
+        25 => "Mushroom Kingdom II",
+        27 => "Flat Zone",
+        28 => "Dream Land",
+        29 => "Yoshi's Island (N64)",
+        30 => "Kongo Jungle (N64)",
+        36 => "Battlefield",
+        37 => "Final Destination",
+        _ => return None,
+    })
+}
+
+/// Maps an external (`Game Start` replay) stage ID to its internal ID.
+fn external_to_internal(external_id: u16) -> Option<u16> {
+    Some(match external_id {
+        2 => 12,
+        3 => 16,
+        4 => 2,
+        5 => 4,
+        6 => 8,
+        7 => 14,
+        8 => 10,
+        9 => 20,
+        10 => 18,
+        11 => 3,
+        12 => 5,
+        13 => 6,
+        14 => 7,
+        15 => 9,
+        16 => 11,
+        17 => 13,
+        18 => 21,
+        19 => 24,
+        20 => 25,
+        22 => 15,
+        23 => 17,
+        24 => 19,
+        25 => 22,
+        27 => 27,
+        28 => 28,
+        29 => 29,
+        30 => 30,
+        31 => 36,
+        32 => 37,
+        _ => return None,
+    })
+}
+
+/// Returns the display name for an external stage ID, if known.
+pub(crate) fn stage_name(external_id: u16) -> Option<&'static str> {
+    stage_name_internal(external_to_internal(external_id)?)
+}
+
+/// Returns the Discord asset key for an external stage ID.
+pub(crate) fn stage_asset(external_id: u16) -> String {
+    match external_to_internal(external_id) {
+        Some(internal_id) => format!("stage{internal_id}"),
+        None => "questionmark".to_string(),
+    }
+}
+
+/// Returns the Discord asset key for an internal stage ID. The stage assets are
+/// keyed by internal ID, so this matches what [`stage_asset`] produces.
+pub(crate) fn stage_asset_internal(internal_id: u16) -> String {
+    match stage_name_internal(internal_id) {
+        Some(_) => format!("stage{internal_id}"),
+        None => "questionmark".to_string(),
+    }
+}

--- a/discord-rpc/src/menu.rs
+++ b/discord-rpc/src/menu.rs
@@ -1,0 +1,131 @@
+//! The Slippi matchmaking state, pushed from the C++ side once per online
+//! frame, and the small enums it maps to. This is what drives menu and queue
+//! presence. There are no memory reads.
+
+/// `SlippiMatchmaking::OnlinePlayMode`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OnlineMode {
+    Ranked,
+    Unranked,
+    Direct,
+    Teams,
+    Party,
+}
+
+impl OnlineMode {
+    fn from_id(id: u8) -> Option<Self> {
+        Some(match id {
+            0 => Self::Ranked,
+            1 => Self::Unranked,
+            2 => Self::Direct,
+            3 => Self::Teams,
+            4 => Self::Party,
+            _ => return None,
+        })
+    }
+
+    /// The human-readable label for this online mode, shown in presence text.
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Ranked => "Ranked",
+            Self::Unranked => "Unranked",
+            Self::Direct => "Direct",
+            Self::Teams => "Teams",
+            Self::Party => "Party",
+        }
+    }
+}
+
+/// `SlippiMatchmaking::ProcessState`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum ProcessState {
+    #[default]
+    Idle,
+    Initializing,
+    Matchmaking,
+    OpponentConnecting,
+    ConnectionSuccess,
+    Error,
+}
+
+impl ProcessState {
+    fn from_id(id: u8) -> Self {
+        match id {
+            1 => Self::Initializing,
+            2 => Self::Matchmaking,
+            3 => Self::OpponentConnecting,
+            4 => Self::ConnectionSuccess,
+            5 => Self::Error,
+            _ => Self::Idle,
+        }
+    }
+}
+
+/// A snapshot of Slippi's matchmaking layer, pushed from the C++ side once per
+/// online frame. Equality drives edge-detection on the presence thread.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct MatchmakingState {
+    pub process: ProcessState,
+    pub mode: Option<OnlineMode>,
+    pub opponent_name: Option<String>,
+    /// `None` when unknown; the C++ side sends a negative rank in that case.
+    pub opponent_rank: Option<i8>,
+}
+
+impl MatchmakingState {
+    /// Builds the typed snapshot from the raw matchmaking values pushed over the
+    /// C++ FFI each online frame.
+    pub(crate) fn from_ffi(process_state: u8, online_mode: u8, opponent_name: Option<String>, opponent_rank: i8) -> Self {
+        Self {
+            process: ProcessState::from_id(process_state),
+            mode: OnlineMode::from_id(online_mode),
+            opponent_name,
+            opponent_rank: (opponent_rank >= 0).then_some(opponent_rank),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_state_maps_known_and_unknown() {
+        let cases = [
+            (0, ProcessState::Idle),
+            (1, ProcessState::Initializing),
+            (5, ProcessState::Error),
+            (6, ProcessState::Idle),
+            (255, ProcessState::Idle),
+        ];
+
+        for (id, expected) in cases {
+            assert_eq!(ProcessState::from_id(id), expected);
+        }
+    }
+
+    #[test]
+    fn online_mode_includes_party() {
+        assert_eq!(OnlineMode::from_id(4), Some(OnlineMode::Party));
+        assert_eq!(OnlineMode::from_id(9), None);
+    }
+
+    #[test]
+    fn from_ffi_normalizes_negative_rank() {
+        let unknown = MatchmakingState::from_ffi(2, 0, None, -1);
+        assert_eq!(unknown.opponent_rank, None);
+
+        let known = MatchmakingState::from_ffi(3, 0, None, 0);
+        assert_eq!(known.opponent_rank, Some(0));
+    }
+
+    #[test]
+    fn from_ffi_builds_expected_state() {
+        let state = MatchmakingState::from_ffi(2, 0, Some("Mango".to_string()), 13);
+
+        assert_eq!(state.process, ProcessState::Matchmaking);
+        assert_eq!(state.mode, Some(OnlineMode::Ranked));
+        assert_eq!(state.opponent_name.as_deref(), Some("Mango"));
+        assert_eq!(state.opponent_rank, Some(13));
+    }
+}

--- a/discord-rpc/src/parser.rs
+++ b/discord-rpc/src/parser.rs
@@ -1,0 +1,435 @@
+//! An incremental parser for the Slippi replay event stream.
+//!
+//! This is the same byte stream that gets written to `.slp` files: the game
+//! writes replay events over EXI, Dolphin forwards each payload to
+//! `slprs_exi_device_reporter_push_replay_data`, and we tap that flow here.
+//!
+//! Only the handful of events (and fields) needed for rich presence are
+//! parsed; everything else is skipped via the payload size table. Offsets
+//! reference the spec at
+//! https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md and
+//! include the command byte (i.e. offset 0x0 is the command itself).
+
+use dolphin_integrations::Log;
+
+const CMD_EVENT_PAYLOADS: u8 = 0x35;
+const CMD_GAME_START: u8 = 0x36;
+const CMD_POST_FRAME: u8 = 0x38;
+const CMD_GAME_END: u8 = 0x39;
+
+/// Extracts the raw event stream from a `.slp` file, or `None` if the data is
+/// too short or isn't a `.slp`. The `.slp` container is UBJSON whose `raw`
+/// element holds the same byte stream the EXI device feeds us live, so a saved
+/// game can be replayed through `EventParser`. See the crate examples.
+pub fn raw_replay_stream(slp_file: &[u8]) -> Option<&[u8]> {
+    // `{U\x03raw[$U#l`, then a u32 big-endian length, then the stream.
+    const HEADER: &[u8] = b"{U\x03raw[$U#l";
+
+    if slp_file.len() < 15 || &slp_file[..11] != HEADER {
+        return None;
+    }
+
+    let length = u32::from_be_bytes(slp_file[11..15].try_into().ok()?) as usize;
+    slp_file.get(15..15 + length)
+}
+
+/// Per-player information pulled from the `Game Start` event.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlayerInfo {
+    pub port: u8,
+    pub character_id: u8,
+    pub costume_id: u8,
+    pub starting_stocks: u8,
+    pub display_name: String,
+    pub connect_code: String,
+}
+
+/// Information pulled from the `Game Start` event (replay versions >= 3.14
+/// fill in the match fields; older versions leave them empty/zero).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GameStartInfo {
+    pub stage_id: u16,
+    pub players: Vec<PlayerInfo>,
+    pub match_id: String,
+    pub game_number: u32,
+    pub tiebreaker_number: u32,
+}
+
+/// Events that consumers of the stream care about.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SlpEvent {
+    GameStart(GameStartInfo),
+
+    /// Emitted once per player per frame; carries the live stock count
+    /// and damage so a consumer can track score changes.
+    PostFrame {
+        player: u8,
+        stocks: u8,
+        percent: f32,
+    },
+
+    /// `end_method`: 1 = TIME!, 2 = GAME!, 7 = No Contest.
+    /// `placements[port]` is 0 for the winner (-1 when not applicable).
+    GameEnd {
+        end_method: u8,
+        lras_initiator: i8,
+        placements: [i8; 4],
+    },
+}
+
+/// Accumulates raw stream bytes and emits `SlpEvent`s as complete events
+/// become available. Feed it data with `push`; chunk boundaries don't need
+/// to align with event boundaries.
+#[derive(Debug)]
+pub struct EventParser {
+    buffer: Vec<u8>,
+    payload_sizes: [u16; 256],
+}
+
+impl EventParser {
+    /// Creates an empty parser. The payload-size table is learned from the
+    /// first `Event Payloads` command in the stream.
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            payload_sizes: [0; 256],
+        }
+    }
+
+    /// Appends a chunk of the replay stream and invokes `on_event` once for
+    /// each complete event. Chunk boundaries need not align with event
+    /// boundaries.
+    pub fn push(&mut self, data: &[u8], mut on_event: impl FnMut(SlpEvent)) {
+        // A fresh Event Payloads command starts a new game, and Dolphin
+        // forwards each payload as a whole chunk, so leftover buffered bytes
+        // when one arrives mean the previous game's stream was cut short.
+        // Resync onto the new game rather than wait for a truncated event.
+        if data.first() == Some(&CMD_EVENT_PAYLOADS) && !self.buffer.is_empty() {
+            tracing::info!(
+                target: Log::DiscordRpc,
+                discarded = self.buffer.len(),
+                "New game started mid-event, discarding truncated stream data"
+            );
+            self.buffer.clear();
+        }
+
+        self.buffer.extend_from_slice(data);
+
+        loop {
+            let Some(&command) = self.buffer.first() else {
+                return;
+            };
+
+            let event_len = if command == CMD_EVENT_PAYLOADS {
+                // Need the length byte; a declared length of 0 is malformed,
+                // so drop the byte and resync rather than looping on it.
+                match self.buffer.get(1) {
+                    None => return,
+                    Some(0) => {
+                        self.buffer.remove(0);
+                        continue;
+                    },
+                    Some(&len) => 1 + len as usize,
+                }
+            } else {
+                match self.payload_sizes[command as usize] {
+                    // An unknown command means we've lost sync with the
+                    // stream (or never saw an Event Payloads command). Drop
+                    // the buffer rather than spinning forever.
+                    0 => {
+                        tracing::warn!(target: Log::DiscordRpc, command, "Unknown replay command, resetting parser");
+                        self.buffer.clear();
+                        return;
+                    },
+                    size => 1 + size as usize,
+                }
+            };
+
+            if self.buffer.len() < event_len {
+                return;
+            }
+
+            let event: Vec<u8> = self.buffer.drain(..event_len).collect();
+
+            match command {
+                CMD_EVENT_PAYLOADS => self.read_payload_sizes_table(&event),
+                CMD_GAME_START => {
+                    if let Some(info) = parse_game_start(&event) {
+                        on_event(SlpEvent::GameStart(info));
+                    }
+                },
+                CMD_POST_FRAME => {
+                    if let Some(event) = parse_post_frame(&event) {
+                        on_event(event);
+                    }
+                },
+                CMD_GAME_END => {
+                    if let Some(event) = parse_game_end(&event) {
+                        on_event(event);
+                    }
+                },
+                _ => {},
+            }
+        }
+    }
+
+    /// The Event Payloads command declares the byte size of every other
+    /// command in the stream; it's always the first event of a game.
+    fn read_payload_sizes_table(&mut self, event: &[u8]) {
+        self.payload_sizes = [0; 256];
+
+        // `get(2..)` rather than `event[2..]`: a degenerate (0- or 1-byte
+        // payload) declaration would otherwise panic, and a panic on this
+        // thread aborts the whole process. A short event just yields an empty
+        // table, which self-heals via the unknown-command reset in `push`.
+        for entry in event.get(2..).unwrap_or_default().chunks_exact(3) {
+            let command = entry[0] as usize;
+            self.payload_sizes[command] = u16::from_be_bytes([entry[1], entry[2]]);
+        }
+    }
+}
+
+impl Default for EventParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn parse_game_start(event: &[u8]) -> Option<GameStartInfo> {
+    let stage_id = read_u16(event, 0x13)?;
+
+    let mut players = Vec::new();
+
+    for port in 0u8..4 {
+        let i = port as usize;
+
+        // Player type: 0 = human, 1 = CPU, 2 = demo, 3 = empty.
+        let player_type = read_u8(event, 0x66 + 0x24 * i)?;
+        if player_type > 1 {
+            continue;
+        }
+
+        players.push(PlayerInfo {
+            port,
+            character_id: read_u8(event, 0x65 + 0x24 * i)?,
+            starting_stocks: read_u8(event, 0x67 + 0x24 * i)?,
+            costume_id: read_u8(event, 0x68 + 0x24 * i)?,
+            // Added in replay version 3.9.0; reads resolve to empty
+            // strings on older versions.
+            display_name: read_shift_jis_string(event, 0x1A5 + 0x1F * i, 31),
+            connect_code: read_shift_jis_string(event, 0x221 + 0xA * i, 10),
+        });
+    }
+
+    Some(GameStartInfo {
+        stage_id,
+        players,
+        // Added in replay version 3.14.0.
+        match_id: read_shift_jis_string(event, 0x2BE, 51),
+        game_number: read_u32(event, 0x2F1).unwrap_or(0),
+        tiebreaker_number: read_u32(event, 0x2F5).unwrap_or(0),
+    })
+}
+
+fn parse_post_frame(event: &[u8]) -> Option<SlpEvent> {
+    // Ignore follower entities (Ice Climbers' Nana).
+    if read_u8(event, 0x6)? != 0 {
+        return None;
+    }
+
+    Some(SlpEvent::PostFrame {
+        player: read_u8(event, 0x5)?,
+        stocks: read_u8(event, 0x21)?,
+        percent: f32::from_bits(read_u32(event, 0x16)?),
+    })
+}
+
+fn parse_game_end(event: &[u8]) -> Option<SlpEvent> {
+    let mut placements = [-1i8; 4];
+
+    // Placements were added in replay version 3.13.0.
+    for (i, placement) in placements.iter_mut().enumerate() {
+        if let Some(value) = read_u8(event, 0x3 + i) {
+            *placement = value as i8;
+        }
+    }
+
+    Some(SlpEvent::GameEnd {
+        end_method: read_u8(event, 0x1)?,
+        lras_initiator: read_u8(event, 0x2).map(|v| v as i8).unwrap_or(-1),
+        placements,
+    })
+}
+
+fn read_u8(data: &[u8], offset: usize) -> Option<u8> {
+    data.get(offset).copied()
+}
+
+fn read_u16(data: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_be_bytes(data.get(offset..offset + 2)?.try_into().ok()?))
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_be_bytes(data.get(offset..offset + 4)?.try_into().ok()?))
+}
+
+/// Reads a null-terminated Shift-JIS string field.
+fn read_shift_jis_string(data: &[u8], offset: usize, max_len: usize) -> String {
+    match data.get(offset..offset + max_len) {
+        Some(field) => crate::text::decode_shift_jis(field),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a miniature replay stream: an Event Payloads declaration, a
+    /// Game Start, one Post Frame per player and a Game End.
+    fn test_stream() -> Vec<u8> {
+        let mut stream = vec![
+            CMD_EVENT_PAYLOADS,
+            10,
+            CMD_GAME_START,
+            0x02,
+            0xF8,
+            CMD_POST_FRAME,
+            0x00,
+            0x50,
+            CMD_GAME_END,
+            0x00,
+            0x06,
+        ];
+
+        let mut game_start = vec![0u8; 0x2F8 + 1];
+        game_start[0] = CMD_GAME_START;
+        game_start[0x13..0x15].copy_from_slice(&31u16.to_be_bytes());
+
+        for (i, character) in [(0usize, 2u8), (1usize, 20u8)] {
+            game_start[0x65 + 0x24 * i] = character;
+            game_start[0x66 + 0x24 * i] = 0;
+            game_start[0x67 + 0x24 * i] = 4;
+        }
+
+        // Ports 3 and 4 are empty.
+        game_start[0x66 + 0x24 * 2] = 3;
+        game_start[0x66 + 0x24 * 3] = 3;
+
+        game_start[0x1A5..0x1A5 + 4].copy_from_slice(b"Andy");
+        // Connect code with a Shift-JIS fullwidth hash: "AA＃1".
+        game_start[0x221..0x221 + 5].copy_from_slice(&[b'A', b'A', 0x81, 0x94, b'1']);
+        game_start[0x2BE..0x2BE + 12].copy_from_slice(b"mode.ranked-");
+        game_start[0x2F1..0x2F5].copy_from_slice(&3u32.to_be_bytes());
+
+        stream.extend_from_slice(&game_start);
+
+        for (player, stocks) in [(0u8, 4u8), (1u8, 3u8)] {
+            let mut post_frame = vec![0u8; 0x50 + 1];
+            post_frame[0] = CMD_POST_FRAME;
+            post_frame[0x5] = player;
+            post_frame[0x16..0x1A].copy_from_slice(&42.5f32.to_be_bytes());
+            post_frame[0x21] = stocks;
+            stream.extend_from_slice(&post_frame);
+        }
+
+        let mut game_end = vec![0u8; 7];
+        game_end[0] = CMD_GAME_END;
+        game_end[0x1] = 2;
+        game_end[0x2] = 0xFF;
+        game_end[0x3..0x7].copy_from_slice(&[1, 0, 0xFF_u8, 0xFF_u8]);
+        stream.extend_from_slice(&game_end);
+
+        stream
+    }
+
+    fn parse(stream: &[u8], chunk_size: usize) -> Vec<SlpEvent> {
+        let mut parser = EventParser::new();
+        let mut events = Vec::new();
+
+        for chunk in stream.chunks(chunk_size) {
+            parser.push(chunk, |event| events.push(event));
+        }
+
+        events
+    }
+
+    #[test]
+    fn parses_a_full_game() {
+        let events = parse(&test_stream(), usize::MAX);
+        assert_eq!(events.len(), 4);
+
+        let SlpEvent::GameStart(info) = &events[0] else {
+            panic!("expected GameStart, got {:?}", events[0]);
+        };
+
+        assert_eq!(info.stage_id, 31);
+        assert_eq!(info.match_id, "mode.ranked-");
+        assert_eq!(info.game_number, 3);
+        assert_eq!(info.players.len(), 2);
+        assert_eq!(info.players[0].character_id, 2);
+        assert_eq!(info.players[0].starting_stocks, 4);
+        assert_eq!(info.players[0].display_name, "Andy");
+        assert_eq!(info.players[0].connect_code, "AA#1");
+        assert_eq!(info.players[1].character_id, 20);
+
+        assert_eq!(
+            events[1],
+            SlpEvent::PostFrame {
+                player: 0,
+                stocks: 4,
+                percent: 42.5
+            }
+        );
+
+        assert_eq!(
+            events[3],
+            SlpEvent::GameEnd {
+                end_method: 2,
+                lras_initiator: -1,
+                placements: [1, 0, -1, -1],
+            }
+        );
+    }
+
+    #[test]
+    fn handles_arbitrary_chunk_boundaries() {
+        let stream = test_stream();
+
+        for chunk_size in [1, 7, 64, 333] {
+            assert_eq!(parse(&stream, chunk_size).len(), 4, "chunk size {chunk_size}");
+        }
+    }
+
+    #[test]
+    fn recovers_from_a_truncated_game() {
+        let stream = test_stream();
+        let mut parser = EventParser::new();
+        let mut events = Vec::new();
+
+        // A game that gets cut off partway through an event...
+        parser.push(&stream[..40], |event| events.push(event));
+        assert_eq!(events.len(), 0);
+
+        // ...followed by a fresh game (whole-chunk pushes, like Dolphin
+        // sends them) parses cleanly.
+        parser.push(&stream, |event| events.push(event));
+        assert_eq!(events.len(), 4);
+    }
+
+    #[test]
+    fn survives_degenerate_event_payloads() {
+        let mut parser = EventParser::new();
+
+        // A zero-length Event Payloads declaration, then random garbage, must
+        // not panic (a panic on the presence thread aborts Dolphin). The
+        // parser drops the bad byte and resyncs, then handles a real game.
+        for stream in [&[CMD_EVENT_PAYLOADS, 0x00][..], &[CMD_EVENT_PAYLOADS, 0x00, 0xAB, 0xCD][..]] {
+            parser.push(stream, |_| panic!("no events expected from garbage"));
+        }
+
+        let mut events = 0;
+        parser.push(&test_stream(), |_| events += 1);
+        assert_eq!(events, 4);
+    }
+}

--- a/discord-rpc/src/presence.rs
+++ b/discord-rpc/src/presence.rs
@@ -1,0 +1,786 @@
+//! The background thread that owns the Discord IPC connection and turns
+//! parsed replay events and pushed matchmaking state into presence updates.
+
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+use discord_rich_presence::activity::{Activity, Assets, Button, Party, Timestamps};
+use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
+use dolphin_integrations::Log;
+use slippi_user::{RankFetchStatus, UserManager};
+
+use crate::Message;
+use crate::content::{GameState, PresenceContent, SetScore, game_details, game_state_line, rank_asset_key, rank_name, unix_time};
+use crate::melee;
+use crate::menu::{MatchmakingState, ProcessState};
+use crate::parser::{EventParser, SlpEvent};
+use crate::scene::SceneState;
+
+/// The Discord application that hosts the presence image assets.
+const DISCORD_CLIENT_ID: &str = "1096595344600604772";
+
+/// Base URL for the "Get Slippi" and profile buttons shown to others.
+const SLIPPI_URL: &str = "https://slippi.gg/";
+
+/// How often the thread wakes up to flush throttled updates and retry the
+/// Discord connection when no data is arriving.
+const TICK_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Discord rate-limits activity updates to roughly one every four seconds.
+const MIN_UPDATE_INTERVAL: Duration = Duration::from_secs(4);
+
+/// How long to wait between attempts to (re)connect to a Discord client.
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// All presence state lives here, owned by the presence thread and mutated only
+/// in response to a `Message`. Nothing on the C++/EXI side ever reads it back,
+/// so unlike `GameReporterQueue` or `UserManager` there's no `Arc<Mutex<>>` to
+/// share; the channel is the only way in, which keeps the locking story empty.
+pub(crate) struct PresenceRunner {
+    client: Option<DiscordIpcClient>,
+    last_connect_attempt: Option<Instant>,
+    last_update: Option<Instant>,
+    pending_update: bool,
+    activity_visible: bool,
+    game: Option<GameState>,
+    set_score: SetScore,
+    matchmaking: MatchmakingState,
+    scene: SceneState,
+    user_manager: Option<UserManager>,
+    show_rank: bool,
+}
+
+/// Thread entry point: drains the message channel, feeds the parser, and
+/// pushes presence updates until shutdown.
+pub(crate) fn run(receiver: Receiver<Message>, user_manager: Option<UserManager>) -> crate::Result<()> {
+    let mut parser = EventParser::new();
+
+    let mut runner = PresenceRunner::new(user_manager);
+
+    loop {
+        // Wake periodically to flush rate-limited updates.
+        let message = match receiver.recv_timeout(TICK_INTERVAL) {
+            Ok(message) => Some(message),
+            Err(RecvTimeoutError::Timeout) => None,
+
+            // Normal shutdown goes through Message::Shutdown, so a bare disconnect is unexpected.
+            Err(error @ RecvTimeoutError::Disconnected) => return Err(error.into()),
+        };
+
+        match message {
+            Some(Message::ReplayData(data)) => {
+                parser.push(&data, |event| runner.handle_event(event));
+            },
+
+            Some(Message::Matchmaking {
+                process_state,
+                online_mode,
+                opponent_name,
+                opponent_rank,
+            }) => {
+                let state = MatchmakingState::from_ffi(process_state, online_mode, opponent_name, opponent_rank);
+                runner.handle_matchmaking(state);
+            },
+
+            Some(Message::Scene {
+                major,
+                minor,
+                char_ids,
+                local_port,
+                stage_id,
+            }) => {
+                let state = SceneState::from_ffi(major, minor, char_ids, local_port, stage_id);
+                runner.handle_scene(state);
+            },
+
+            Some(Message::ShowRank(show_rank)) => {
+                if runner.show_rank != show_rank {
+                    runner.show_rank = show_rank;
+                    runner.pending_update = true;
+                }
+            },
+
+            Some(Message::Shutdown) => break,
+            None => {},
+        }
+
+        runner.flush();
+    }
+
+    runner.clear();
+    tracing::info!(target: Log::DiscordRpc, "Discord presence thread shutting down");
+    Ok(())
+}
+
+impl PresenceRunner {
+    /// Creates a runner with no Discord connection yet and default state.
+    fn new(user_manager: Option<UserManager>) -> Self {
+        Self {
+            client: None,
+            last_connect_attempt: None,
+            last_update: None,
+            // Start dirty so the baseline "in menus" presence shows as soon as
+            // we connect, before any game or matchmaking frame arrives.
+            pending_update: true,
+            activity_visible: false,
+            game: None,
+            set_score: SetScore::default(),
+            matchmaking: MatchmakingState::default(),
+            scene: SceneState::default(),
+            user_manager,
+            // Default on; Dolphin overrides via set_show_rank.
+            show_rank: true,
+        }
+    }
+
+    /// Folds a parsed replay event into the current game state, flagging a
+    /// presence refresh when something player-visible changed.
+    fn handle_event(&mut self, event: SlpEvent) {
+        match event {
+            SlpEvent::GameStart(info) => {
+                if self.set_score.match_id != info.match_id {
+                    self.set_score = SetScore {
+                        match_id: info.match_id.clone(),
+                        wins: [0; 4],
+                    };
+                }
+
+                tracing::info!(
+                    target: Log::DiscordRpc,
+                    stage = ?melee::stage_name(info.stage_id),
+                    match_id = %info.match_id,
+                    game_number = info.game_number,
+                    "Game started"
+                );
+
+                let mut stocks = [0; 4];
+
+                for player in &info.players {
+                    stocks[player.port as usize] = player.starting_stocks;
+                }
+
+                self.game = Some(GameState {
+                    info,
+                    stocks,
+                    started_at: unix_time(),
+                    ended: false,
+                });
+
+                self.pending_update = true;
+            },
+
+            SlpEvent::PostFrame { player, stocks, .. } => {
+                let Some(game) = self.game.as_mut() else { return };
+
+                if game.ended || player as usize >= 4 {
+                    return;
+                }
+
+                if game.stocks[player as usize] != stocks {
+                    game.stocks[player as usize] = stocks;
+                    self.pending_update = true;
+                }
+            },
+
+            SlpEvent::GameEnd { placements, .. } => {
+                let Some(game) = self.game.as_mut() else { return };
+
+                game.ended = true;
+
+                if let Some(winner_port) = placements.iter().position(|&p| p == 0) {
+                    if winner_port < 4 {
+                        self.set_score.wins[winner_port] += 1;
+                    }
+                }
+
+                tracing::info!(
+                    target: Log::DiscordRpc,
+                    wins = ?self.set_score.wins,
+                    "Game ended"
+                );
+
+                self.pending_update = true;
+            },
+        }
+    }
+
+    /// Folds a pushed matchmaking snapshot into presence state. A live game
+    /// keeps ownership of presence until it ends.
+    fn handle_matchmaking(&mut self, state: MatchmakingState) {
+        if state == self.matchmaking {
+            return;
+        }
+
+        let game_is_live = self.game.as_ref().is_some_and(|game| !game.ended);
+
+        // A live game owns presence; just record the new state for later.
+        if game_is_live && state.process == ProcessState::ConnectionSuccess {
+            self.matchmaking = state;
+            return;
+        }
+
+        // Back to matchmaking with no live game: drop any finished game so its
+        // result stops showing.
+        if !game_is_live && state.process != ProcessState::ConnectionSuccess {
+            self.game = None;
+        }
+
+        tracing::debug!(target: Log::DiscordRpc, ?state, "Matchmaking state changed");
+        self.matchmaking = state;
+        self.pending_update = true;
+    }
+
+    /// Folds a pushed scene snapshot into presence state. A live game keeps
+    /// ownership of presence; returning to the character-select screen clears a
+    /// finished game so its result stops showing.
+    fn handle_scene(&mut self, state: SceneState) {
+        if state == self.scene {
+            return;
+        }
+
+        // Log only on a real scene change, not on every cursor move, so the
+        // raw major/minor is visible while testing without flooding the log.
+        if (state.major, state.minor) != (self.scene.major, self.scene.minor) {
+            tracing::info!(target: Log::DiscordRpc, major = state.major, minor = state.minor, "Scene changed");
+        }
+
+        // Back on the character-select screen with a finished game still around:
+        // drop it so the offline result stops showing.
+        if state.is_css() && self.game.as_ref().is_some_and(|game| game.ended) {
+            self.game = None;
+        }
+
+        self.scene = state;
+        self.pending_update = true;
+    }
+
+    /// Pushes the current state to Discord, respecting the rate limit.
+    fn flush(&mut self) {
+        if !self.pending_update {
+            return;
+        }
+
+        if let Some(last) = self.last_update {
+            if last.elapsed() < MIN_UPDATE_INTERVAL {
+                return;
+            }
+        }
+
+        if !self.ensure_connected() {
+            return;
+        }
+
+        let Some(content) = self.content() else {
+            self.clear();
+            self.pending_update = false;
+            return;
+        };
+
+        let mut assets = Assets::new()
+            .large_image(&content.large_image)
+            .large_text(&content.large_text);
+
+        if let Some(image) = &content.small_image {
+            assets = assets.small_image(image);
+        }
+
+        if let Some(text) = &content.small_text {
+            assets = assets.small_text(text);
+        }
+
+        // Owned so the Button borrows outlive set_activity.
+        let button_data = self.buttons();
+        let buttons = button_data
+            .iter()
+            .map(|(label, url)| Button::new(label.as_str(), url.as_str()))
+            .collect();
+
+        let mut activity = Activity::new()
+            .details(&content.details)
+            .state(&content.state)
+            .assets(assets)
+            .buttons(buttons);
+
+        if let Some(start) = content.start_timestamp {
+            activity = activity.timestamps(Timestamps::new().start(start));
+        }
+
+        if let Some((current, max)) = content.party {
+            activity = activity.party(Party::new().size([current as i32, max as i32]));
+        }
+
+        let Some(client) = self.client.as_mut() else {
+            return;
+        };
+
+        match client.set_activity(activity) {
+            Ok(_) => {
+                self.pending_update = false;
+                self.activity_visible = true;
+                self.last_update = Some(Instant::now());
+                tracing::info!(
+                    target: Log::DiscordRpc,
+                    details = %content.details,
+                    state = %content.state,
+                    "Updated Discord presence"
+                );
+            },
+
+            Err(error) => {
+                tracing::warn!(target: Log::DiscordRpc, ?error, "Failed to update Discord presence, dropping connection");
+                self.client = None;
+            },
+        }
+    }
+
+    /// Decides what presence to show right now, or `None` to show nothing.
+    fn content(&self) -> Option<PresenceContent> {
+        // A live or just-finished game always wins.
+        if let Some(game) = &self.game {
+            return Some(self.game_content(game));
+        }
+
+        // The online matchmaking flow owns presence whenever it's active.
+        if !matches!(self.matchmaking.process, ProcessState::Idle | ProcessState::Error) {
+            return Some(self.matchmaking_content());
+        }
+
+        // Offline scene presence: character select, training, the 1P modes,
+        // offline Vs before the game starts producing replay data.
+        if let Some(content) = self.scene_content() {
+            return Some(content);
+        }
+
+        // Default: the online idle baseline ("In menus").
+        Some(self.matchmaking_content())
+    }
+
+    /// Presence for the online menu and matchmaking flow, keyed off the pushed
+    /// `MatchmakingState`.
+    fn matchmaking_content(&self) -> PresenceContent {
+        let mm = &self.matchmaking;
+        match mm.process {
+            ProcessState::Idle | ProcessState::Error => {
+                let (large_image, large_text) = self.player_badge();
+                PresenceContent {
+                    details: "Slippi Online".to_string(),
+                    state: "In menus".to_string(),
+                    large_image,
+                    large_text,
+                    ..Default::default()
+                }
+            },
+
+            ProcessState::Initializing | ProcessState::Matchmaking => {
+                let (large_image, large_text) = self.player_badge();
+                let details = match mm.mode {
+                    Some(mode) => format!("In queue - {}", mode.name()),
+                    None => "In queue".to_string(),
+                };
+                PresenceContent {
+                    details,
+                    state: "Searching for an opponent".to_string(),
+                    large_image,
+                    large_text,
+                    party: Some((1, 2)),
+                    ..Default::default()
+                }
+            },
+
+            ProcessState::OpponentConnecting => {
+                let (large_image, large_text) = self.opponent_badge();
+                PresenceContent {
+                    details: "Opponent found".to_string(),
+                    state: match &mm.opponent_name {
+                        Some(name) => format!("vs {name}"),
+                        None => "Connecting...".to_string(),
+                    },
+                    large_image,
+                    large_text,
+                    party: Some((2, 2)),
+                    ..Default::default()
+                }
+            },
+
+            ProcessState::ConnectionSuccess => {
+                let (large_image, large_text) = self.player_badge();
+                PresenceContent {
+                    details: "Starting match...".to_string(),
+                    state: match &mm.opponent_name {
+                        Some(name) => format!("vs {name}"),
+                        None => "Starting...".to_string(),
+                    },
+                    large_image,
+                    large_text,
+                    party: Some((2, 2)),
+                    ..Default::default()
+                }
+            },
+        }
+    }
+
+    /// Presence for the offline scenes that never reach the replay stream: the
+    /// character-select screen (showing the local player's hovered character)
+    /// and the recognized offline modes. `None` when the current scene isn't
+    /// one we render, so the caller falls back to the menu baseline.
+    fn scene_content(&self) -> Option<PresenceContent> {
+        let scene = &self.scene;
+
+        if scene.is_css() {
+            let local_char = scene.local_char_id();
+
+            let (small_image, small_text) = match local_char {
+                Some(id) => (Some(melee::character_asset(id)), melee::character_name(id).map(String::from)),
+                None => (None, None),
+            };
+
+            let (large_image, large_text) = self.player_badge();
+
+            return Some(PresenceContent {
+                details: "Choosing characters".to_string(),
+                state: match local_char.and_then(melee::character_name) {
+                    Some(name) => name.to_string(),
+                    None => "Character select".to_string(),
+                },
+                large_image,
+                large_text,
+                small_image,
+                small_text,
+                ..Default::default()
+            });
+        }
+
+        let mode = scene.mode_label()?;
+
+        // Stage-select screen: show that a stage is being picked.
+        if scene.is_sss() {
+            let (large_image, large_text) = self.player_badge();
+            return Some(PresenceContent {
+                details: mode.to_string(),
+                state: "Choosing a stage".to_string(),
+                large_image,
+                large_text,
+                ..Default::default()
+            });
+        }
+
+        // A loaded stage (e.g. training on a stage) is featured as the large
+        // image, the same way an in-game match is.
+        if let Some(stage_id) = scene.stage() {
+            if let Some(name) = melee::stage_name_internal(stage_id as u16) {
+                return Some(PresenceContent {
+                    details: mode.to_string(),
+                    state: name.to_string(),
+                    large_image: melee::stage_asset_internal(stage_id as u16),
+                    large_text: name.to_string(),
+                    ..Default::default()
+                });
+            }
+        }
+
+        let (large_image, large_text) = self.player_badge();
+
+        Some(PresenceContent {
+            details: mode.to_string(),
+            state: "Offline".to_string(),
+            large_image,
+            large_text,
+            ..Default::default()
+        })
+    }
+
+    /// Large image + hover text for the opponent-found state: the opponent's
+    /// rank badge when known and rank display is on, otherwise the Slippi logo.
+    fn opponent_badge(&self) -> (String, String) {
+        if self.show_rank {
+            if let Some(rank) = self.matchmaking.opponent_rank.filter(|&r| r > 0) {
+                if let Some(name) = rank_name(rank) {
+                    return (rank_asset_key(name), name.to_string());
+                }
+            }
+        }
+
+        self.player_badge()
+    }
+
+    /// The player's rank badge as (asset key, label) once a real rank has been
+    /// fetched, or `None` when the player has hidden their rank in-game.
+    fn rank_badge(&self) -> Option<(String, String)> {
+        if !self.show_rank {
+            return None;
+        }
+
+        let user_manager = self.user_manager.as_ref()?;
+        let (info, status) = user_manager.current_rank_and_status();
+
+        if !matches!(status, RankFetchStatus::Fetched) || info.rank == 0 {
+            return None;
+        }
+
+        let name = rank_name(info.rank)?;
+        let asset = rank_asset_key(name);
+        let text = format!("{name} · {}", info.rating_ordinal.round() as i32);
+
+        Some((asset, text))
+    }
+
+    /// Large image + hover text representing the local player in any non-game
+    /// state: their rank badge once fetched, otherwise the generic Slippi logo.
+    fn player_badge(&self) -> (String, String) {
+        self.rank_badge()
+            .unwrap_or_else(|| ("slippi".to_string(), "Slippi Online".to_string()))
+    }
+
+    /// Buttons shown to other viewers: a Get Slippi link plus the player's
+    /// slippi.gg profile when their connect code is known.
+    fn buttons(&self) -> Vec<(String, String)> {
+        let mut buttons = vec![("Get Slippi".to_string(), SLIPPI_URL.to_string())];
+
+        if let Some(url) = self.profile_url() {
+            buttons.push(("View Slippi Profile".to_string(), url));
+        }
+
+        buttons
+    }
+
+    /// The slippi.gg profile URL for the logged-in player, e.g. `SWOO#0` ->
+    /// `https://slippi.gg/user/swoo-0`, if their connect code is known.
+    fn profile_url(&self) -> Option<String> {
+        let code = self.user_manager.as_ref()?.get(|user| user.connect_code.clone());
+
+        code.contains('#')
+            .then(|| format!("{SLIPPI_URL}user/{}", code.to_lowercase().replace('#', "-")))
+    }
+
+    /// Presence for an in-progress or just-finished game: stage as the large
+    /// image, the local player's character as the small image, and the live
+    /// stock line / set score as details.
+    fn game_content(&self, game: &GameState) -> PresenceContent {
+        let stage_asset = melee::stage_asset(game.info.stage_id);
+        let stage_text = melee::stage_name(game.info.stage_id).unwrap_or("Unknown stage").to_string();
+
+        let (small_image, small_text) = match game.info.players.first() {
+            Some(player) => (
+                Some(melee::character_asset(player.character_id)),
+                melee::character_name(player.character_id).map(String::from),
+            ),
+            None => (None, None),
+        };
+
+        let players = game.info.players.len() as u32;
+
+        PresenceContent {
+            details: game_details(game, &self.set_score),
+            state: game_state_line(game),
+            large_image: stage_asset,
+            large_text: stage_text,
+            small_image,
+            small_text,
+            start_timestamp: Some(game.started_at),
+            party: (players > 0).then_some((players, players)),
+        }
+    }
+
+    /// Connects to a running Discord client if not already connected, with a
+    /// reconnect cooldown.
+    fn ensure_connected(&mut self) -> bool {
+        if self.client.is_some() {
+            return true;
+        }
+
+        if let Some(last) = self.last_connect_attempt {
+            if last.elapsed() < RECONNECT_INTERVAL {
+                return false;
+            }
+        }
+
+        self.last_connect_attempt = Some(Instant::now());
+
+        let mut client = DiscordIpcClient::new(DISCORD_CLIENT_ID);
+
+        match client.connect() {
+            Ok(_) => {
+                tracing::info!(target: Log::DiscordRpc, "Connected to Discord");
+                self.client = Some(client);
+                true
+            },
+
+            Err(error) => {
+                tracing::warn!(target: Log::DiscordRpc, ?error, "Could not connect to Discord (is it running?)");
+                false
+            },
+        }
+    }
+
+    /// Clears the Discord activity if one is currently shown.
+    fn clear(&mut self) {
+        if !self.activity_visible {
+            return;
+        }
+
+        if let Some(client) = self.client.as_mut() {
+            let _ = client.clear_activity();
+            self.activity_visible = false;
+        }
+    }
+}
+
+impl Drop for PresenceRunner {
+    fn drop(&mut self) {
+        if let Some(client) = self.client.as_mut() {
+            let _ = client.clear_activity();
+            let _ = client.close();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::menu::OnlineMode;
+
+    fn test_runner() -> PresenceRunner {
+        PresenceRunner::new(None)
+    }
+
+    fn state(process: ProcessState) -> MatchmakingState {
+        MatchmakingState {
+            process,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn matchmaking_change_flags_an_update() {
+        let mut runner = test_runner();
+        runner.pending_update = false;
+        runner.handle_matchmaking(state(ProcessState::Matchmaking));
+        assert_eq!(runner.matchmaking.process, ProcessState::Matchmaking);
+        assert!(runner.pending_update);
+    }
+
+    #[test]
+    fn identical_matchmaking_state_is_a_no_op() {
+        let mut runner = test_runner();
+        runner.matchmaking = state(ProcessState::Matchmaking);
+        runner.pending_update = false;
+        runner.handle_matchmaking(state(ProcessState::Matchmaking));
+        assert!(!runner.pending_update);
+    }
+
+    #[test]
+    fn starts_dirty_so_the_baseline_presence_shows() {
+        assert!(test_runner().pending_update);
+    }
+
+    #[test]
+    fn a_live_game_survives_a_connection_success_frame() {
+        let mut runner = test_runner();
+        runner.game = Some(GameState {
+            ended: false,
+            ..Default::default()
+        });
+        runner.handle_matchmaking(state(ProcessState::ConnectionSuccess));
+        assert!(runner.game.is_some());
+    }
+
+    #[test]
+    fn a_finished_game_clears_when_back_in_menus() {
+        let mut runner = test_runner();
+        runner.matchmaking = state(ProcessState::ConnectionSuccess);
+        runner.game = Some(GameState {
+            ended: true,
+            ..Default::default()
+        });
+        runner.handle_matchmaking(state(ProcessState::Idle));
+        assert!(runner.game.is_none());
+    }
+
+    #[test]
+    fn idle_renders_in_menus() {
+        let content = test_runner().content().unwrap();
+        assert_eq!(content.details, "Slippi Online");
+        assert_eq!(content.state, "In menus");
+    }
+
+    #[test]
+    fn queueing_renders_mode_and_party() {
+        let mut runner = test_runner();
+        runner.matchmaking = MatchmakingState {
+            process: ProcessState::Matchmaking,
+            mode: Some(OnlineMode::Ranked),
+            ..Default::default()
+        };
+        let content = runner.content().unwrap();
+        assert_eq!(content.details, "In queue - Ranked");
+        assert_eq!(content.party, Some((1, 2)));
+    }
+
+    #[test]
+    fn opponent_connecting_renders_their_name() {
+        let mut runner = test_runner();
+        runner.matchmaking = MatchmakingState {
+            process: ProcessState::OpponentConnecting,
+            opponent_name: Some("Mango".to_string()),
+            ..Default::default()
+        };
+        let content = runner.content().unwrap();
+        assert_eq!(content.details, "Opponent found");
+        assert_eq!(content.state, "vs Mango");
+    }
+
+    /// A CSS scene (Versus major, CSS minor) with Falco hovered on the local
+    /// port renders "Choosing characters" + the character icon.
+    fn falco_css_scene() -> SceneState {
+        SceneState::from_ffi(0x02, 0x00, [0xFF, 0x14, 0xFF, 0xFF], 1, 0)
+    }
+
+    #[test]
+    fn css_scene_renders_choosing_characters_with_hovered_char() {
+        let mut runner = test_runner();
+        runner.scene = falco_css_scene();
+        let content = runner.content().unwrap();
+        assert_eq!(content.details, "Choosing characters");
+        assert_eq!(content.state, "Falco");
+        assert_eq!(content.small_image.as_deref(), Some("char20"));
+    }
+
+    #[test]
+    fn a_live_game_outranks_a_css_scene() {
+        let mut runner = test_runner();
+        runner.scene = falco_css_scene();
+        runner.game = Some(GameState {
+            ended: false,
+            ..Default::default()
+        });
+        // game_details falls back to "Online" for an empty match id.
+        assert_eq!(runner.content().unwrap().details, "Online");
+    }
+
+    #[test]
+    fn active_matchmaking_outranks_a_css_scene() {
+        let mut runner = test_runner();
+        runner.scene = falco_css_scene();
+        runner.matchmaking = state(ProcessState::Matchmaking);
+        assert_eq!(runner.content().unwrap().details, "In queue");
+    }
+
+    #[test]
+    fn idle_with_a_css_scene_shows_the_scene() {
+        let mut runner = test_runner();
+        runner.scene = falco_css_scene();
+        // Idle matchmaking, no game: the scene wins over the "In menus" baseline.
+        assert_eq!(runner.content().unwrap().details, "Choosing characters");
+    }
+
+    #[test]
+    fn returning_to_css_clears_a_finished_game() {
+        let mut runner = test_runner();
+        runner.game = Some(GameState {
+            ended: true,
+            ..Default::default()
+        });
+        runner.handle_scene(falco_css_scene());
+        assert!(runner.game.is_none());
+    }
+}

--- a/discord-rpc/src/scene.rs
+++ b/discord-rpc/src/scene.rs
@@ -1,0 +1,160 @@
+//! The live Melee scene and character-select state, pushed from the C++ side
+//! over the menu-frame heartbeat. This is what drives presence for the
+//! character-select screen and the offline scenes (training, the 1P modes,
+//! offline Vs) that never reach the replay stream, so unlike everything else in
+//! this crate it depends on Dolphin telling us the current scene. There are no
+//! memory reads here; the bytes arrive over FFI exactly like `MatchmakingState`.
+
+/// External character ID sentinel for an empty or disabled character-select
+/// port. Mirrors the `0xFF` the C++ side writes for a port no one is on.
+const PORT_EMPTY: u8 = 0xFF;
+
+/// `Scene.major` for the Versus-mode group, which owns the character- and
+/// stage-select screens.
+const MAJOR_VS: u8 = 0x02;
+
+/// `Scene.major` for Training mode (shared by UnclePunch).
+const MAJOR_TRAINING: u8 = 0x1C;
+
+/// `Scene.major` for the online Versus group (ranked and unranked). The
+/// character-select cursor is read from RAM here because the matchmaking FFI
+/// has nothing to push before a search starts.
+const MAJOR_VS_ONLINE: u8 = 0x08;
+
+/// `Scene.minor` for a character-select screen (within a mode that has one).
+const MINOR_CSS: u8 = 0x00;
+
+/// `Scene.minor` for the Versus stage-select screen.
+const MINOR_SSS: u8 = 0x01;
+
+/// A snapshot of the Melee scene controller and the character-select cards,
+/// pushed from the C++ side once per menu-frame heartbeat. Equality drives
+/// edge-detection on the presence thread, exactly like `MatchmakingState`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SceneState {
+    /// `Scene.major`: the broad mode (Versus, Training, a 1P mode, online).
+    pub major: u8,
+
+    /// `Scene.minor`: the screen within that mode (character select, stage
+    /// select, in-game).
+    pub minor: u8,
+
+    /// The external character ID hovered or selected on each port; `0xFF` for
+    /// an empty port. Only meaningful on the character-select screen.
+    pub char_ids: [u8; 4],
+
+    /// The 0-based port of the local player on the character-select screen.
+    pub local_port: u8,
+
+    /// The internal stage ID of the loaded stage, or 0 when none is loaded
+    /// (a menu or character-select screen).
+    pub stage_id: u8,
+}
+
+impl SceneState {
+    pub(crate) fn from_ffi(major: u8, minor: u8, char_ids: [u8; 4], local_port: u8, stage_id: u8) -> Self {
+        Self {
+            major,
+            minor,
+            char_ids,
+            local_port,
+            stage_id,
+        }
+    }
+
+    /// The character-select screen of any mode that has one.
+    pub(crate) fn is_css(&self) -> bool {
+        self.minor == MINOR_CSS && matches!(self.major, MAJOR_VS | MAJOR_TRAINING | MAJOR_VS_ONLINE)
+    }
+
+    /// The stage-select screen of any mode that has one.
+    pub(crate) fn is_sss(&self) -> bool {
+        self.minor == MINOR_SSS && matches!(self.major, MAJOR_VS | MAJOR_TRAINING | MAJOR_VS_ONLINE)
+    }
+
+    /// The local player's hovered character, when a real one is under the
+    /// cursor. `None` on an empty port or a port off the roster.
+    pub(crate) fn local_char_id(&self) -> Option<u8> {
+        let id = *self.char_ids.get(self.local_port as usize)?;
+        (id != PORT_EMPTY).then_some(id)
+    }
+
+    /// The internal ID of the loaded stage, when one is loaded.
+    pub(crate) fn stage(&self) -> Option<u8> {
+        (self.stage_id != 0).then_some(self.stage_id)
+    }
+
+    /// A label for the current offline mode, or `None` for menus and online
+    /// scenes that presence handles elsewhere. Drives the `details` line for
+    /// character-select, stage-select and in-mode scenes.
+    pub(crate) fn mode_label(&self) -> Option<&'static str> {
+        Some(match self.major {
+            MAJOR_VS => "Versus",
+            MAJOR_TRAINING => "Training Mode",
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn css(char_ids: [u8; 4], local_port: u8) -> SceneState {
+        SceneState::from_ffi(MAJOR_VS, MINOR_CSS, char_ids, local_port, 0)
+    }
+
+    #[test]
+    fn css_detected_for_each_mode_with_a_character_select() {
+        // Versus, Training and online Versus each have a character-select screen.
+        for major in [MAJOR_VS, MAJOR_TRAINING, MAJOR_VS_ONLINE] {
+            assert!(SceneState::from_ffi(major, MINOR_CSS, [PORT_EMPTY; 4], 0, 0).is_css());
+        }
+        assert!(!SceneState::from_ffi(MAJOR_VS, MINOR_SSS, [PORT_EMPTY; 4], 0, 0).is_css());
+        assert!(!SceneState::default().is_css());
+    }
+
+    #[test]
+    fn stage_is_some_only_when_loaded() {
+        assert_eq!(SceneState::default().stage(), None);
+        assert_eq!(
+            SceneState::from_ffi(MAJOR_TRAINING, 0x02, [PORT_EMPTY; 4], 0, 0x20).stage(),
+            Some(0x20)
+        );
+    }
+
+    #[test]
+    fn local_char_id_respects_port_and_empty_sentinel() {
+        // Falco (0x14) on port 1, everything else empty.
+        let scene = css([PORT_EMPTY, 0x14, PORT_EMPTY, PORT_EMPTY], 1);
+        assert_eq!(scene.local_char_id(), Some(0x14));
+
+        // Local player sits on an empty port.
+        let scene = css([0x14, PORT_EMPTY, PORT_EMPTY, PORT_EMPTY], 1);
+        assert_eq!(scene.local_char_id(), None);
+    }
+
+    #[test]
+    fn stage_select_detected_for_vs_and_training() {
+        assert!(SceneState::from_ffi(MAJOR_VS, MINOR_SSS, [PORT_EMPTY; 4], 0, 0).is_sss());
+        assert!(SceneState::from_ffi(MAJOR_TRAINING, MINOR_SSS, [PORT_EMPTY; 4], 0, 0).is_sss());
+        assert!(!SceneState::from_ffi(MAJOR_TRAINING, MINOR_CSS, [PORT_EMPTY; 4], 0, 0).is_sss());
+    }
+
+    #[test]
+    fn mode_label_covers_offline_modes() {
+        assert_eq!(
+            SceneState::from_ffi(MAJOR_TRAINING, 0x02, [PORT_EMPTY; 4], 0, 0).mode_label(),
+            Some("Training Mode")
+        );
+        assert_eq!(SceneState::default().mode_label(), None);
+    }
+
+    #[test]
+    fn default_scene_is_unrecognized() {
+        let scene = SceneState::default();
+        assert!(!scene.is_css());
+        assert!(!scene.is_sss());
+        assert_eq!(scene.mode_label(), None);
+    }
+}

--- a/discord-rpc/src/text.rs
+++ b/discord-rpc/src/text.rs
@@ -1,0 +1,37 @@
+/// Decodes a null-terminated Shift-JIS byte field. Names and connect codes
+/// are mostly ASCII; the one common multi-byte case is the fullwidth `＃` in
+/// connect codes, mapped to `#`. Other multi-byte sequences are skipped.
+pub(crate) fn decode_shift_jis(field: &[u8]) -> String {
+    let mut result = String::new();
+    let mut i = 0;
+
+    while i < field.len() {
+        match field[i] {
+            0x00 => break,
+            0x81 if field.get(i + 1) == Some(&0x94) => {
+                result.push('#');
+                i += 2;
+            },
+            byte if byte.is_ascii() && !byte.is_ascii_control() => {
+                result.push(byte as char);
+                i += 1;
+            },
+            0x81..=0x9F | 0xE0..=0xFC => i += 2,
+            _ => i += 1,
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_shift_jis;
+
+    #[test]
+    fn decodes_ascii_and_fullwidth_hash() {
+        assert_eq!(decode_shift_jis(b"SWOO\x81\x940\x00junk"), "SWOO#0");
+        assert_eq!(decode_shift_jis(b"plain"), "plain");
+        assert_eq!(decode_shift_jis(&[0x00]), "");
+    }
+}

--- a/dolphin/src/logger/mod.rs
+++ b/dolphin/src/logger/mod.rs
@@ -53,6 +53,9 @@ pub mod Log {
 
     /// Can be used to segment Jukebox logs.
     pub const Jukebox: &'static str = "SLIPPI_RUST_JUKEBOX";
+
+    /// Can be used to segment Discord Rich Presence logs.
+    pub const DiscordRpc: &'static str = "SLIPPI_RUST_DISCORD_RPC";
 }
 
 /// Represents a `LogContainer` on the Dolphin side.

--- a/exi/Cargo.toml
+++ b/exi/Cargo.toml
@@ -23,6 +23,7 @@ playback = [
 
 [dependencies]
 dolphin-integrations = { path = "../dolphin" }
+slippi-discord-rpc = { path = "../discord-rpc" }
 slippi-game-reporter = { path = "../game-reporter" }
 slippi-gg-api = { path = "../slippi-gg-api" }
 slippi-jukebox = { path = "../jukebox" }

--- a/exi/src/lib.rs
+++ b/exi/src/lib.rs
@@ -6,6 +6,7 @@
 //! Slippi stuff is happening" and enables us to let the Rust side live in its own world.
 
 use dolphin_integrations::Log;
+use slippi_discord_rpc::DiscordHandler;
 use slippi_game_reporter::GameReporter;
 use slippi_gg_api::APIClient;
 use slippi_jukebox::Jukebox;
@@ -21,6 +22,7 @@ pub struct SlippiEXIDevice {
     pub game_reporter: GameReporter,
     pub user_manager: UserManager,
     pub jukebox: Option<Jukebox>,
+    pub discord_rpc: Option<DiscordHandler>,
 }
 
 pub enum JukeboxConfiguration {
@@ -29,6 +31,16 @@ pub enum JukeboxConfiguration {
         initial_dolphin_music_volume: u8,
     },
     Stop,
+}
+
+pub enum DiscordRpcConfiguration {
+    Start { show_rank: bool },
+    Stop,
+}
+
+/// `None` for an empty string.
+fn non_empty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
 }
 
 impl SlippiEXIDevice {
@@ -63,11 +75,22 @@ impl SlippiEXIDevice {
             game_reporter,
             user_manager,
             jukebox: None,
+            discord_rpc: None,
         }
     }
 
     /// Stubbed for now, but this would get called by the C++ EXI device on DMAWrite.
     pub fn dma_write(&mut self, _address: usize, _size: usize) {}
+
+    /// Receives a chunk of the replay event stream from the C++ side and
+    /// fans it out to everything interested in it.
+    pub fn push_replay_data(&mut self, data: &[u8]) {
+        self.game_reporter.push_replay_data(data);
+
+        if let Some(discord_rpc) = &self.discord_rpc {
+            discord_rpc.push_replay_data(data);
+        }
+    }
 
     /// Stubbed for now, but this would get called by the C++ EXI device on DMARead.
     pub fn dma_read(&mut self, _address: usize, _size: usize) {}
@@ -104,6 +127,51 @@ impl SlippiEXIDevice {
                     "Failed to start Jukebox"
                 ),
             }
+        }
+    }
+
+    /// Configures Discord Rich Presence, or drops an existing handler if it's
+    /// being disabled.
+    pub fn configure_discord_rpc(&mut self, config: DiscordRpcConfiguration) {
+        let DiscordRpcConfiguration::Start { show_rank } = config else {
+            self.discord_rpc = None;
+            return;
+        };
+
+        if self.discord_rpc.is_none() {
+            match DiscordHandler::new(Some(self.user_manager.clone())) {
+                Ok(handler) => {
+                    self.discord_rpc = Some(handler);
+                },
+
+                Err(e) => {
+                    tracing::error!(
+                        target: Log::SlippiOnline,
+                        error = ?e,
+                        "Failed to start Discord Rich Presence"
+                    );
+
+                    return;
+                },
+            }
+        }
+
+        if let Some(discord_rpc) = &self.discord_rpc {
+            discord_rpc.set_show_rank(show_rank);
+        }
+    }
+
+    /// Forwards a matchmaking-state snapshot to the Discord presence thread, if active.
+    pub fn update_matchmaking_state(&self, process_state: u8, online_mode: u8, opponent_name: String, opponent_rank: i8) {
+        if let Some(discord_rpc) = &self.discord_rpc {
+            discord_rpc.update_matchmaking_state(process_state, online_mode, non_empty(opponent_name), opponent_rank);
+        }
+    }
+
+    /// Forwards a scene + character-select snapshot to the Discord presence thread, if active.
+    pub fn update_scene_state(&self, major_scene: u8, minor_scene: u8, char_ids: [u8; 4], local_port: u8, stage_id: u8) {
+        if let Some(discord_rpc) = &self.discord_rpc {
+            discord_rpc.update_scene_state(major_scene, minor_scene, char_ids, local_port, stage_id);
         }
     }
 }

--- a/ffi/includes/SlippiRustExtensions.h
+++ b/ffi/includes/SlippiRustExtensions.h
@@ -101,6 +101,40 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * Configures Discord Rich Presence. `show_rank` is the player's in-game
+ * rank-display preference; when false, the presence omits the rank badge.
+ */
+void slprs_exi_device_configure_discord_rpc(uintptr_t exi_device_instance_ptr,
+                                            bool is_enabled,
+                                            bool show_rank);
+
+/**
+ * Pushes the current Slippi matchmaking state to Discord Rich Presence. The
+ * Rust side edge-detects and only re-renders when something changes.
+ * `opponent_name` may be null or empty when unknown; `opponent_rank` is
+ * negative when unknown.
+ */
+void slprs_exi_device_update_matchmaking_state(uintptr_t exi_device_instance_ptr,
+                                               uint8_t process_state,
+                                               uint8_t online_mode,
+                                               const char *opponent_name,
+                                               int8_t opponent_rank);
+
+/**
+ * Pushes the current Melee scene and character-select state to Discord Rich
+ * Presence, mirroring how matchmaking state is pushed. `css_char_ids` points
+ * to four external Melee character IDs (one per port); `0xFF` marks an empty
+ * port. `local_port` is the 0-based port of the local player. The Rust side
+ * edge-detects and only re-renders when something changes.
+ */
+void slprs_exi_device_update_scene_state(uintptr_t exi_device_instance_ptr,
+                                         uint8_t major_scene,
+                                         uint8_t minor_scene,
+                                         const uint8_t *css_char_ids,
+                                         uint8_t local_port,
+                                         uint8_t stage_id);
+
+/**
  * Creates and leaks a shadow EXI device with the provided configuration.
  *
  * The C++ (Dolphin) side of things should call this and pass the appropriate arguments. At

--- a/ffi/src/discord_rpc.rs
+++ b/ffi/src/discord_rpc.rs
@@ -1,0 +1,87 @@
+use std::ffi::c_char;
+
+use slippi_exi_device::{DiscordRpcConfiguration, SlippiEXIDevice};
+
+use crate::c_str_to_string;
+
+/// Configures Discord Rich Presence. `show_rank` is the player's in-game
+/// rank-display preference; when false, the presence omits the rank badge.
+#[unsafe(no_mangle)]
+pub extern "C" fn slprs_exi_device_configure_discord_rpc(exi_device_instance_ptr: usize, is_enabled: bool, show_rank: bool) {
+    // Coerce the instance from the pointer. This is theoretically safe since we control
+    // the C++ side and can guarantee that the `exi_device_instance_ptr` is only owned
+    // by the C++ EXI device, and is created/destroyed with the corresponding lifetimes.
+    let mut device = unsafe { Box::from_raw(exi_device_instance_ptr as *mut SlippiEXIDevice) };
+
+    let discord_rpc_config = match is_enabled {
+        true => DiscordRpcConfiguration::Start { show_rank },
+        false => DiscordRpcConfiguration::Stop,
+    };
+    device.configure_discord_rpc(discord_rpc_config);
+
+    // Fall back into a raw pointer so Rust doesn't obliterate the object.
+    let _leak = Box::into_raw(device);
+}
+
+/// Pushes the current Slippi matchmaking state to Discord Rich Presence. The
+/// Rust side edge-detects and only re-renders when something changes.
+/// `opponent_name` may be null or empty when unknown; `opponent_rank` is
+/// negative when unknown.
+#[unsafe(no_mangle)]
+pub extern "C" fn slprs_exi_device_update_matchmaking_state(
+    exi_device_instance_ptr: usize,
+    process_state: u8,
+    online_mode: u8,
+    opponent_name: *const c_char,
+    opponent_rank: i8,
+) {
+    // Coerce the instance from the pointer. This is theoretically safe since we control
+    // the C++ side and can guarantee that the `exi_device_instance_ptr` is only owned
+    // by the C++ EXI device, and is created/destroyed with the corresponding lifetimes.
+    let device = unsafe { Box::from_raw(exi_device_instance_ptr as *mut SlippiEXIDevice) };
+
+    let fn_name = "slprs_exi_device_update_matchmaking_state";
+    let opponent_name = match opponent_name.is_null() {
+        true => String::new(),
+        false => c_str_to_string(opponent_name, fn_name, "opponent_name"),
+    };
+
+    device.update_matchmaking_state(process_state, online_mode, opponent_name, opponent_rank);
+
+    // Fall back into a raw pointer so Rust doesn't obliterate the object.
+    let _leak = Box::into_raw(device);
+}
+
+/// Pushes the current Melee scene and character-select state to Discord Rich
+/// Presence, mirroring how matchmaking state is pushed. `css_char_ids` points
+/// to four external Melee character IDs (one per port); `0xFF` marks an empty
+/// port. `local_port` is the 0-based port of the local player. The Rust side
+/// edge-detects and only re-renders when something changes.
+#[unsafe(no_mangle)]
+pub extern "C" fn slprs_exi_device_update_scene_state(
+    exi_device_instance_ptr: usize,
+    major_scene: u8,
+    minor_scene: u8,
+    css_char_ids: *const u8,
+    local_port: u8,
+    stage_id: u8,
+) {
+    // Coerce the instance from the pointer. This is theoretically safe since we control
+    // the C++ side and can guarantee that the `exi_device_instance_ptr` is only owned
+    // by the C++ EXI device, and is created/destroyed with the corresponding lifetimes.
+    let device = unsafe { Box::from_raw(exi_device_instance_ptr as *mut SlippiEXIDevice) };
+
+    let char_ids = match css_char_ids.is_null() {
+        true => [0xFF; 4],
+        false => {
+            // The C++ side always passes a fixed four-byte, port-indexed array.
+            let slice = unsafe { std::slice::from_raw_parts(css_char_ids, 4) };
+            [slice[0], slice[1], slice[2], slice[3]]
+        },
+    };
+
+    device.update_scene_state(major_scene, minor_scene, char_ids, local_port, stage_id);
+
+    // Fall back into a raw pointer so Rust doesn't obliterate the object.
+    let _leak = Box::into_raw(device);
+}

--- a/ffi/src/exi.rs
+++ b/ffi/src/exi.rs
@@ -208,7 +208,7 @@ pub extern "C" fn slprs_exi_device_reporter_push_replay_data(instance_ptr: usize
     // by us, and are created/destroyed with the corresponding lifetimes.
     let mut device = unsafe { Box::from_raw(instance_ptr as *mut SlippiEXIDevice) };
 
-    device.game_reporter.push_replay_data(slice);
+    device.push_replay_data(slice);
 
     // Fall back into a raw pointer so Rust doesn't obliterate the object.
     let _leak = Box::into_raw(device);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -9,6 +9,7 @@ use std::ffi::{CStr, c_char};
 
 use dolphin_integrations::Log;
 
+pub mod discord_rpc;
 pub mod exi;
 pub mod game_reporter;
 pub mod jukebox;


### PR DESCRIPTION
Adds Discord Rich Presence as a new `discord-rpc` crate. It mirrors live Slippi state to a local Discord client and links to your slippi.gg profile, so people can see what you're playing and check each other's profiles easily.

## What it shows

**Online (no memory reads):**
- In-game: stage, characters, live stocks, set score. This comes off the replay event stream the EXI device already tees to the extension, so there are no memory reads.
- Menus, queue, opponent and rank between games: pushed from Slippi's own `SlippiMatchmaking` over a small FFI (`slprs_exi_device_update_matchmaking_state`), so that side doesn't read emulated memory either.

**Character select, stage select and offline modes:**
- The character you're hovering on the CSS, the stage on the SSS, and the loaded stage in Training and the other offline modes.

## How it's built

Everything runs on one background thread owned by the EXI device, like jukebox. Discord I/O is local IPC, and nothing else is affected if Discord isn't running. The activity honors the in-game rank-display setting.

## On the memory reads (and where I'm unsure)

For multiplayer/online I deliberately kept it free of memory reads, since reading RAM is something the team keeps away from: the in-game and matchmaking halves ride the replay tee and the matchmaking FFI.

The character-select / stage / offline part is the one piece that currently reads a small set of fixed Melee addresses directly (NTSC 1.02), as a stand-in, because there's no existing channel pushing that state out. The clean version would have the Slippi SSBM ASM emit the same bytes over EXI on the menu-frame command (currently defined but disabled), after which nothing reads RAM. The Rust side is written against that exact shape already, so switching the source is a one-block change on the C++ side and nothing here moves.

I'm genuinely unsure the scene part is the right approach, and I'd love feedback: whether the ASM-over-EXI path is something you'd want, and how you'd prefer the local-player port and scene state to be sourced. Happy to change direction or drop it.

The game-side glue is a companion PR on each Dolphin fork: project-slippi/dolphin#67 (mainline) and project-slippi/Ishiiruka#464 (stable). `discord-rpc/README.md` covers how it hooks in.

Verified with the unit tests and the `simulate` / `simulate_queue` examples against a real Discord client, plus a from-source mainline build.
